### PR TITLE
fix: honor core.hooksPath when installing the post-merge dispatcher

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Zayhan"
   },
   "description": "Marketplace publishing the Espalier Engineering plugin — auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -13,7 +13,7 @@
         "repo": "Junhanliu-dev/espalier-engineering"
       },
       "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
   "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Zayhan"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.1 — 2026-05-22
+
+Patch: `scripts/bootstrap-espalier.sh` now honors `git config core.hooksPath`.
+
+- Bootstrap Stage 9 wrote the post-merge dispatcher to a hard-coded `.git/hooks/post-merge` (or `.husky/post-merge`). When a repo sets `core.hooksPath` — husky v9, lefthook, or an org-wide global hooks dir — git ignores `.git/hooks` entirely, so the dispatcher landed at a path git never reads: `drift-detect.sh` and `post-merge-backlink.sh` silently never ran. Stage 9 now resolves `core.hooksPath` and installs to git's real hooks dir.
+- A `core.hooksPath` that points outside the repo (e.g. a stale absolute path inherited from a repo copy/rename) cannot be wired safely — Stage 9 now skips the install and prints a fix instead of a false success. A value containing `..` is rejected for the same reason.
+- Validation check 20 (`post-merge-dispatcher`) greps the resolved hooks dir instead of the fixed `.git/hooks` path, so it can no longer report a green check for a dispatcher git will never execute.
+- `scripts/test-bootstrap.sh` gains Test 12 — covers the inside-repo install and the outside-repo refusal.
+
+Verified with the smoke suite (51 asserts across 12 tests) and a live end-to-end run: a `core.hooksPath` repo, the real bootstrap, and a real `git merge` firing the dispatcher.
+
 ## 0.5.0 — 2026-05-20
 
 Doc-drift detection. The artifacts `/espalier-init` generates — rules, wiki, layer specs, hooks — no longer silently rot as the codebase evolves. v0.5.0 adds detection, surfacing, gated remediation, and validation, **without ever auto-overwriting a doc** and without a hook that dirties the working tree.

--- a/scripts/bootstrap-espalier.sh
+++ b/scripts/bootstrap-espalier.sh
@@ -506,15 +506,61 @@ stage_merge_decision() {
     fi
   fi
 
+  # Resolve where git ACTUALLY looks for hooks. A set core.hooksPath overrides
+  # .git/hooks entirely, so a dispatcher written to .git/hooks would be a silent
+  # no-op. husky manages its own core.hooksPath (-> .husky/_) and routes
+  # .husky/post-merge for us, so when husky is present we trust it.
+  HOOK_DST=""
   if [ "$HUSKY_PRESENT" = "yes" ]; then
     HOOK_DST=".husky/post-merge"
   else
-    HOOK_DST=".git/hooks/post-merge"
+    HOOKS_PATH_CFG=$(git config core.hooksPath 2>/dev/null || true)
+    if [ -z "$HOOKS_PATH_CFG" ]; then
+      HOOK_DST=".git/hooks/post-merge"
+    else
+      # core.hooksPath is set and husky is not managing it. The dispatcher must
+      # land where git reads — and only if that is inside this repo. A hooksPath
+      # pointing elsewhere (another repo, a global hooks dir) cannot be wired.
+      REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+      HOOKS_DIR_ABS=""
+      case "$HOOKS_PATH_CFG" in
+        *..*) ;;                                                 # '..' may escape the repo — reject
+        /*)   HOOKS_DIR_ABS="${HOOKS_PATH_CFG%/}" ;;             # absolute
+        *)    HOOKS_DIR_ABS="$REPO_ROOT/${HOOKS_PATH_CFG%/}" ;;  # relative to repo root
+      esac
+      if [ -z "$HOOKS_DIR_ABS" ]; then
+        log "  WARN: core.hooksPath ('$HOOKS_PATH_CFG') contains '..' — cannot place"
+        log "        the post-merge dispatcher safely. Skipping hook install."
+        log "        Fix core.hooksPath, then re-run: bash bootstrap-espalier.sh --wire-only ..."
+      else
+        case "$HOOKS_DIR_ABS/" in
+          "$REPO_ROOT"/*)
+            HOOK_DST="$HOOKS_DIR_ABS/post-merge"
+            log "  core.hooksPath set → targeting $HOOK_DST"
+            ;;
+          *)
+            log "  WARN: core.hooksPath ('$HOOKS_PATH_CFG') points outside this repo."
+            log "        git ignores .git/hooks here, so the post-merge dispatcher"
+            log "        cannot be installed — drift-detect + squash-backlink will NOT run."
+            log "        Fix: 'git config --unset core.hooksPath' (or point it inside the"
+            log "        repo), then re-run: bash bootstrap-espalier.sh --wire-only ..."
+            ;;
+        esac
+      fi
+    fi
   fi
 
-  if [ ! -d "$(dirname "$HOOK_DST")" ]; then
-    log "  ERROR: $(dirname "$HOOK_DST") does not exist (run 'git init' first?)"
-    return
+  if [ -z "$HOOK_DST" ]; then
+    return   # hooks dir unreachable — warning already emitted; check #20 will flag it
+  fi
+
+  HOOK_DST_PARENT=$(dirname "$HOOK_DST")
+  if [ ! -d "$HOOK_DST_PARENT" ]; then
+    if [ "$HOOK_DST_PARENT" = ".git/hooks" ]; then
+      log "  ERROR: .git/hooks does not exist (run 'git init' first?)"
+      return
+    fi
+    mkdir -p "$HOOK_DST_PARENT" || { log "  ERROR: cannot create $HOOK_DST_PARENT"; return; }
   fi
 
   # Already on the dispatcher → nothing to do (idempotent).
@@ -677,7 +723,7 @@ stage_validate() {
   run_check 17 "merge-decision"      'grep -qE "^(not-needed|installed|fuzzy-allowed|skip-only|never-ask|ask-later)$" espalier/.merge-hook-decision' &
   run_check 18 "hook-template-copy"  'test -f espalier/hooks/post-merge-backlink.sh && test -x espalier/hooks/post-merge-backlink.sh' &
   run_check 19 "lookup-helpers"      'test -f espalier/hooks/lookup-helpers.sh' &
-  run_check 20 "post-merge-dispatcher" 'grep -qE "ESPALIER_POSTMERGE_DISPATCH" .git/hooks/post-merge 2>/dev/null || grep -qE "ESPALIER_POSTMERGE_DISPATCH" .husky/post-merge 2>/dev/null' &
+  run_check 20 "post-merge-dispatcher" '_hd=$(git config core.hooksPath 2>/dev/null); [ -n "$_hd" ] || _hd=.git/hooks; grep -qE "ESPALIER_POSTMERGE_DISPATCH" "$_hd/post-merge" 2>/dev/null || grep -qE "ESPALIER_POSTMERGE_DISPATCH" .husky/post-merge 2>/dev/null' &
   run_check 21 "rebuild-script"      'test -x espalier/hooks/rebuild-commit-index.sh' &
   run_check 22 "gitignore-cache"     'grep -qxF "espalier/.commit-index.tsv" .gitignore' &
   run_check 23 "rebuild-runs"        'bash espalier/hooks/rebuild-commit-index.sh && test -f espalier/.commit-index.tsv' &

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -10,6 +10,7 @@
 #   - settings.json merge preserves user hooks
 #   - portable abspath works without realpath binary
 #   - parallel validation produces sorted output + correct exit code
+#   - core.hooksPath honored (inside-repo install; outside-repo refusal)
 #
 # Usage: bash scripts/test-bootstrap.sh [--keep] [--verbose]
 
@@ -271,6 +272,36 @@ assert "rejects invalid merge-decision"         "echo \"\$INVALID_OUT\" | grep -
 MISSING_OUT=$( cd "$TMP" && bash "$BOOTSTRAP" --lang=ts --plugin-dir="$PLUGIN_DIR" --yes --force 2>&1 || true )
 assert "rejects missing merge-decision"         "echo \"\$MISSING_OUT\" | grep -q 'required for mode'"
 [ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
+# ─── Test 12: core.hooksPath honored ──────────────────────────────────────
+echo "Test 12: core.hooksPath honored"
+
+# 12a — core.hooksPath set INSIDE the repo: the dispatcher must land in that
+#       dir, NOT in .git/hooks, and validation check 20 must still pass.
+TMP=$(mktemp -d -t smoke12a.XXXX)
+make_smoke_repo "$TMP"
+( cd "$TMP" && mkdir -p .githooks && git config core.hooksPath .githooks )
+simulate_llm_writes "$TMP" ts
+HP_IN=$( cd "$TMP" && bash "$BOOTSTRAP" --lang=ts --merge-decision=ask-later --plugin-dir="$PLUGIN_DIR" --yes --force 2>&1 )
+assert "12a Stage 9 logged hooksPath resolution" "echo \"\$HP_IN\" | grep -q 'core.hooksPath set'"
+assert "12a dispatcher at core.hooksPath dir"    "grep -q 'ESPALIER_POSTMERGE_DISPATCH' '$TMP/.githooks/post-merge'"
+assert "12a nothing written to .git/hooks"       "[ ! -f '$TMP/.git/hooks/post-merge' ]"
+assert "12a check 20 passed"                     "echo \"\$HP_IN\" | grep -qF '[20/28] OK'"
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
+# 12b — core.hooksPath set OUTSIDE the repo: bootstrap must refuse to install,
+#       warn, write nothing, and validation check 20 must fail (honest red).
+TMP=$(mktemp -d -t smoke12b.XXXX)
+OUTSIDE=$(mktemp -d -t smoke12bout.XXXX)
+make_smoke_repo "$TMP"
+( cd "$TMP" && git config core.hooksPath "$OUTSIDE" )
+simulate_llm_writes "$TMP" ts
+HP_OUT=$( cd "$TMP" && bash "$BOOTSTRAP" --lang=ts --merge-decision=ask-later --plugin-dir="$PLUGIN_DIR" --yes --force 2>&1 || true )
+assert "12b warns hooksPath outside repo"        "echo \"\$HP_OUT\" | grep -q 'points outside this repo'"
+assert "12b no dispatcher in outside dir"        "[ ! -f '$OUTSIDE/post-merge' ]"
+assert "12b no dispatcher in .git/hooks"         "[ ! -f '$TMP/.git/hooks/post-merge' ]"
+assert "12b check 20 failed (honest red)"        "echo \"\$HP_OUT\" | grep -qF '[20/28] FAIL'"
+[ "$KEEP" != "yes" ] && rm -rf "$TMP" "$OUTSIDE"
 
 # ─── Summary ──────────────────────────────────────────────────────────────
 echo ""

--- a/skills/espalier-init/references/validation.md
+++ b/skills/espalier-init/references/validation.md
@@ -27,7 +27,7 @@ After all generation and wiring is complete, validate end-to-end.
 | 17 | Merge-hook decision cached | `cat espalier/.merge-hook-decision` | One of: not-needed, installed, fuzzy-allowed, skip-only, never-ask, ask-later |
 | 18 | Hook template copied | `test -f espalier/hooks/post-merge-backlink.sh && test -x espalier/hooks/post-merge-backlink.sh` | Exit 0 |
 | 19 | Lookup helpers present | `test -f espalier/hooks/lookup-helpers.sh` | Exit 0 |
-| 20 | Post-merge dispatcher installed | `grep -qE "ESPALIER_POSTMERGE_DISPATCH" .git/hooks/post-merge .husky/post-merge 2>/dev/null` | Match found (dispatcher installed unconditionally; runs drift-detect every merge, backlink only when decision=installed) |
+| 20 | Post-merge dispatcher installed | `_hd=$(git config core.hooksPath); grep -qE "ESPALIER_POSTMERGE_DISPATCH" "${_hd:-.git/hooks}/post-merge" .husky/post-merge 2>/dev/null` | Match found at git's real hooks dir — `core.hooksPath` is honored. Dispatcher installed unconditionally; runs drift-detect every merge, backlink only when decision=installed. If `core.hooksPath` points outside the repo, bootstrap skips the install and warns. |
 | 21 | Rebuild script present + executable | `test -x espalier/hooks/rebuild-commit-index.sh` | Exit 0 |
 | 22 | .gitignore excludes cache | `grep -qxF "espalier/.commit-index.tsv" .gitignore` | Exit 0 |
 | 23 | Manual rebuild produces valid cache | `bash espalier/hooks/rebuild-commit-index.sh && test -f espalier/.commit-index.tsv` | All exit 0 |


### PR DESCRIPTION
## Summary

Bootstrap now installs the post-merge dispatcher where git actually reads hooks, instead of always assuming `.git/hooks/` — fixing a silent no-op in any repo that sets `core.hooksPath`.

## Why

`bootstrap-espalier.sh` Stage 9 hard-coded the dispatcher destination to `.git/hooks/post-merge` (or `.husky/post-merge`). When a repo sets `core.hooksPath` — husky v9, lefthook, or an org-wide global hooks dir — git ignores `.git/hooks` entirely. The dispatcher landed at a path git never executes, so `drift-detect.sh` and `post-merge-backlink.sh` silently never ran. Worse, validation check 20 grepped the same fixed path and reported a green check for a dispatcher git would never run — a false success.

## Changes

- **`scripts/bootstrap-espalier.sh` Stage 9** — resolves `git config core.hooksPath` and installs the dispatcher to git's real hooks dir. A `core.hooksPath` that points outside the repo (e.g. a stale absolute path inherited from a repo copy/rename) or contains `..` cannot be wired safely: Stage 9 skips the install and prints a fix instead of reporting a false success. Creates the resolved hooks dir if missing.
- **`scripts/bootstrap-espalier.sh` check 20** — greps the resolved hooks dir instead of the fixed `.git/hooks` path, so it can no longer report green for an unreachable dispatcher.
- **`scripts/test-bootstrap.sh`** — new Test 12: inside-repo `core.hooksPath` install lands in the right dir + passes check 20; outside-repo `core.hooksPath` is refused with a warning and fails check 20 (honest red).
- **`skills/espalier-init/references/validation.md`** — check 20 row updated to document `core.hooksPath` resolution.
- **Release** — CHANGELOG.md 0.5.1 entry; `plugin.json` + `marketplace.json` bumped 0.5.0 → 0.5.1.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (fix or feature that changes existing skill/script behavior)
- [ ] Docs only
- [ ] Refactor / cleanup (no behavior change)

## Test plan

- [x] `bash scripts/test-bootstrap.sh --verbose` passes — **51/51 asserts across 12 tests** (43 pre-existing + 8 new in Test 12; no regressions). Note: the template's "33/33" is stale.
- [x] All shell scripts pass `bash -n` under `/bin/bash` (macOS 3.2.57)
- [ ] If migration scripts changed: dry-run + apply tested — N/A, no migration script touched
- [ ] If skill templates changed: spawned a test project, ran `/espalier-init` — N/A, only a `references/` doc changed; the bootstrap path `/espalier-init` calls is covered by the smoke suite + the live e2e below
- [x] CHANGELOG.md updated under the next version heading
- [x] Tested on macOS / Linux: **macOS** (Darwin 25.5.0, system bash 3.2)

## Compatibility

- [x] Pure additive — no impact on existing installs
- [ ] Additive — backward-compat fallback retained for v0.3 / v0.2 installs
- [ ] Breaking — migration shim added at `scripts/migrate-v0.4-to-v0.5.sh` (or equivalent)

A repo with no `core.hooksPath` set behaves exactly as before (`.git/hooks/post-merge`). Only the previously-broken `core.hooksPath` case changes.

## Screenshots / output

Live end-to-end: an example repo with `core.hooksPath`, the real bootstrap, a real `git merge`:

```
### 2. Simulate the /espalier-init LLM Write batch + run the REAL patched bootstrap
    [bootstrap]   core.hooksPath set → targeting /.../espalier-e2e.XXXX/.githooks/post-merge
    [20/28] OK   post-merge-dispatcher
    [bootstrap] Validation: 28/28 passed

### 3. Where did the dispatcher land?
    PASS  dispatcher at .githooks/post-merge (the core.hooksPath dir)
    PASS  .git/hooks/post-merge absent (not the dead path)

### 4. Instrument the installed dispatcher with a probe, then do a REAL merge
    [merge] Merge made by the 'ort' strategy.
    [merge] [probe] dispatcher executed by git on merge

### 5. Verdict
    PASS  git ran the dispatcher from core.hooksPath on a real merge
```

Smoke suite:

```
Test 12: core.hooksPath honored
  OK   12a Stage 9 logged hooksPath resolution
  OK   12a dispatcher at core.hooksPath dir
  OK   12a nothing written to .git/hooks
  OK   12a check 20 passed
  OK   12b warns hooksPath outside repo
  OK   12b no dispatcher in outside dir
  OK   12b no dispatcher in .git/hooks
  OK   12b check 20 failed (honest red)

  Tests passed: 51
  Tests failed: 0
```

## Reviewer notes

- **Outside-repo `core.hooksPath` is a hard skip, not a fallback.** When `core.hooksPath` points outside the repo, Stage 9 cannot install anywhere git will read, so it warns and returns. Validation then fails check 20 — deliberately. A loud red beats a silent no-op; the warning tells the user to `git config --unset core.hooksPath` and re-run `--wire-only`.
- husky is unchanged: husky manages its own `core.hooksPath` (→ `.husky/_`) and routes `.husky/post-merge`, so the husky branch still targets `.husky/post-merge` directly.
- The PR template's test-plan line says "33/33" — stale; the suite is now 51 asserts. Not fixed here to keep the diff scoped to the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
