### PR TITLE
fix: honor core.hooksPath in the migration scripts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Zayhan"
   },
   "description": "Marketplace publishing the Espalier Engineering plugin — auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -13,7 +13,7 @@
         "repo": "Junhanliu-dev/espalier-engineering"
       },
       "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
   "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "Zayhan"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.2 — 2026-05-22
+
+Patch: the `core.hooksPath` fix from v0.5.1 extended to the migration scripts.
+
+- `scripts/migrate-v0.4-to-v0.5.sh` — the Step 3 "post-merge dispatcher installed" verification grepped a hard-coded `.git/hooks/post-merge`, the same blind spot v0.5.1 fixed in the bootstrap. On a `core.hooksPath` repo the migration itself succeeded (Step 1 runs the now-fixed `bootstrap-espalier.sh --force`) but the check reported a false failure. It now resolves `core.hooksPath`.
+- `scripts/migrate-v0.1-to-v0.2.sh` — the post-merge hook install now resolves `core.hooksPath` instead of assuming `.git/hooks/`.
+- `scripts/migrate-v0.3-to-v0.4.sh` — the `harness/` → `espalier/` hook-path rewrite now resolves `core.hooksPath` when locating the live hook.
+- `docs/migrating-v0.4-to-v0.5.md` — the manual post-migration verification snippet honors `core.hooksPath`.
+
+No behavior change for repos without `core.hooksPath` set. The canonical resolution (with the outside-repo skip) lives in `bootstrap-espalier.sh` Stage 9; the migration scripts do a plain resolve and the chain's final `bootstrap --force` is the safety net.
+
 ## 0.5.1 — 2026-05-22
 
 Patch: `scripts/bootstrap-espalier.sh` now honors `git config core.hooksPath`.

--- a/docs/migrating-v0.4-to-v0.5.md
+++ b/docs/migrating-v0.4-to-v0.5.md
@@ -80,7 +80,7 @@ The script's 13 checks cover the essentials. Manual smoke after:
 ```bash
 test -f espalier/hooks/drift-detect.sh && echo "drift hooks installed"
 test -L .claude/skills/espalier-prune && test -L .claude/skills/espalier-doctor && echo "new skills wired"
-grep -q ESPALIER_POSTMERGE_DISPATCH .git/hooks/post-merge 2>/dev/null && echo "dispatcher installed"
+_hd=$(git config core.hooksPath 2>/dev/null); grep -q ESPALIER_POSTMERGE_DISPATCH "${_hd:-.git/hooks}/post-merge" .husky/post-merge 2>/dev/null && echo "dispatcher installed"
 cat espalier/.doctor-cadence
 ```
 

--- a/scripts/migrate-v0.1-to-v0.2.sh
+++ b/scripts/migrate-v0.1-to-v0.2.sh
@@ -236,12 +236,14 @@ PROMPT
 
   if [ "$DECISION" = "installed" ]; then
     echo "==> Installing post-merge hook"
+    # Honor core.hooksPath — git ignores .git/hooks entirely when it is set.
     if [ -d ".husky" ]; then
       HOOK_DST=".husky/post-merge"
     else
-      HOOK_DST=".git/hooks/post-merge"
+      HOOK_DST="$(git config core.hooksPath 2>/dev/null || echo .git/hooks)/post-merge"
     fi
     SRC="harness/hooks/post-merge-backlink.sh"
+    run mkdir -p "$(dirname "$HOOK_DST")"
     if [ -f "$HOOK_DST" ] && ! grep -q "HARNESS_BACKLINK_HOOK" "$HOOK_DST"; then
       run "cat \"$SRC\" >> \"$HOOK_DST\""
     elif [ ! -f "$HOOK_DST" ]; then

--- a/scripts/migrate-v0.3-to-v0.4.sh
+++ b/scripts/migrate-v0.3-to-v0.4.sh
@@ -324,7 +324,9 @@ if [ -f ".gitignore" ]; then
   fi
 fi
 
-for HOOK in .git/hooks/post-merge .husky/post-merge; do
+# Honor core.hooksPath — the live post-merge hook may not be under .git/hooks.
+HOOKS_DIR=$(git config core.hooksPath 2>/dev/null || echo .git/hooks)
+for HOOK in "$HOOKS_DIR/post-merge" .husky/post-merge; do
   [ -f "$HOOK" ] || continue
   if [ "$DRY_RUN" = "yes" ]; then
     echo "[dry-run] rewrite $HOOK (harness/ paths → espalier/)"

--- a/scripts/migrate-v0.4-to-v0.5.sh
+++ b/scripts/migrate-v0.4-to-v0.5.sh
@@ -308,7 +308,7 @@ else
   check "espalier-doctor skill present"    "test -f espalier/skills/espalier-doctor/SKILL.md"
   check ".claude/skills/espalier-prune link"  "test -L .claude/skills/espalier-prune"
   check ".claude/skills/espalier-doctor link" "test -L .claude/skills/espalier-doctor"
-  check "post-merge dispatcher installed"  "grep -qE 'ESPALIER_POSTMERGE_DISPATCH' .git/hooks/post-merge .husky/post-merge 2>/dev/null"
+  check "post-merge dispatcher installed"  '_hd=$(git config core.hooksPath 2>/dev/null); [ -n "$_hd" ] || _hd=.git/hooks; grep -qE "ESPALIER_POSTMERGE_DISPATCH" "$_hd/post-merge" .husky/post-merge 2>/dev/null'
   check ".doctor-cadence written"          "grep -qE '^cadence: (every-change|weekly|monthly|manual)$' espalier/.doctor-cadence"
   check ".gitignore has drift sidecars"    "grep -qxF 'espalier/.drift-state.tsv*' .gitignore"
   check "harness-coder.md patched"         "grep -q 'Stale-doc check:' espalier/agents/harness-coder.md"


### PR DESCRIPTION
## Summary

Extends the `core.hooksPath` fix from v0.5.1 (bootstrap) to the three migration scripts and the v0.4→v0.5 migration guide — they had the same hard-coded `.git/hooks/post-merge` assumption.

## Why

v0.5.1 fixed `bootstrap-espalier.sh` to honor `git config core.hooksPath`, but the migration scripts carried independent copies of the same hard-coded path. Most visibly: `migrate-v0.4-to-v0.5.sh` Step 3 verifies the dispatcher by grepping a fixed `.git/hooks/post-merge`. On a `core.hooksPath` repo the migration *succeeds* — Step 1 runs `bootstrap-espalier.sh --force`, now fixed — but the verification then greps the wrong path and prints a **false failure**. Found in review of the v0.5.1 fix: the bug class wasn't fully swept.

## Changes

- **`scripts/migrate-v0.4-to-v0.5.sh`** — Step 3 `post-merge dispatcher installed` check resolves `core.hooksPath` (was a fixed `.git/hooks/post-merge`). Identical to the v0.5.1 check-20 fix.
- **`scripts/migrate-v0.1-to-v0.2.sh`** — post-merge hook install resolves `core.hooksPath` for `HOOK_DST`; `mkdir -p` guards a non-default hooks dir.
- **`scripts/migrate-v0.3-to-v0.4.sh`** — the `harness/` → `espalier/` hook-path rewrite resolves `core.hooksPath` when locating the live hook.
- **`docs/migrating-v0.4-to-v0.5.md`** — the manual post-migration verification snippet honors `core.hooksPath`.
- **Release** — CHANGELOG.md 0.5.2 entry; `plugin.json` + `marketplace.json` bumped 0.5.1 → 0.5.2.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (fix or feature that changes existing skill/script behavior)
- [ ] Docs only
- [ ] Refactor / cleanup (no behavior change)

## Test plan

- [x] `bash -n` on all three migration scripts under `/bin/bash` (macOS 3.2.57) — pass
- [x] Focused e2e (`extracts the actual shipped commands from the files`, runs them against `core.hooksPath` repos) — **10/10**, see output below
- [x] `bash scripts/test-bootstrap.sh` — **51/51**, no regression (bootstrap untouched this PR)
- [ ] Full dry-run + apply against synthetic v0.1/v0.3 fixtures — **not run**: the v0.1→v0.2 / v0.3→v0.4 changes are one-line `core.hooksPath` resolves on code paths masked by the chain's final `bootstrap --force`; covered by `bash -n` + the extracted-command e2e + review
- [x] CHANGELOG.md updated under the next version heading
- [x] Tested on macOS / Linux: **macOS** (Darwin 25.5.0, system bash 3.2)

## Compatibility

- [x] Pure additive — no impact on existing installs
- [ ] Additive — backward-compat fallback retained for v0.3 / v0.2 installs
- [ ] Breaking — migration shim added

Repos without `core.hooksPath` set behave exactly as before (`git config core.hooksPath` returns empty → `.git/hooks` fallback).

## Screenshots / output

```
### Fix 3 — migrate-v0.4-to-v0.5.sh:311 verification check
  OK   no core.hooksPath, dispatcher in .git/hooks → pass
  OK   core.hooksPath set, dispatcher at hooksPath → pass
  OK     (control) .git/hooks/post-merge absent — old check would FALSE-FAIL here
  OK   core.hooksPath set, NO dispatcher → fails (honest red)

### Fix 4 — docs/migrating-v0.4-to-v0.5.md verification snippet
  OK   snippet finds dispatcher at core.hooksPath dir
  OK   snippet finds dispatcher in default .git/hooks

### Fix 1 & 2 — core.hooksPath resolve expression
  OK   unset core.hooksPath → .git/hooks/post-merge
  OK   set core.hooksPath=.githooks → .githooks/post-merge
  OK   migrate-v0.1-to-v0.2.sh has the resolve
  OK   migrate-v0.3-to-v0.4.sh has the resolve

  passed: 10   failed: 0
```

## Reviewer notes

- **`migrate-v0.4-to-v0.5.sh` is the real bug** — a false-red verification check. The migration itself was never broken (Step 1 delegates to the now-fixed bootstrap).
- **`migrate-v0.1-to-v0.2.sh` / `migrate-v0.3-to-v0.4.sh` are latent** — those hard-coded paths are masked because `/espalier-migrate` always ends with `migrate-v0.4-to-v0.5.sh` → `bootstrap-espalier.sh --force`, which installs the dispatcher correctly regardless. Fixed anyway for standalone runs and bug-class consistency.
- **Canonical resolution stays in bootstrap.** The migration scripts do a plain `git config core.hooksPath || echo .git/hooks` resolve. The full logic — outside-repo skip, `..` rejection — lives in `bootstrap-espalier.sh` Stage 9 (v0.5.1); the chain's final `bootstrap --force` is the safety net. Kept the migrate-script diffs minimal rather than copying 40 lines of logic three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
