### PR TITLE
fix: give the coder agent an editing-discipline rule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Zayhan"
   },
   "description": "Marketplace publishing the Espalier Engineering plugin — auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -13,7 +13,7 @@
         "repo": "Junhanliu-dev/espalier-engineering"
       },
       "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
   "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": {
     "name": "Zayhan"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.3 — 2026-05-22
+
+Patch: the coder sub-agent gets an explicit editing-discipline rule.
+
+- **`templates/agents/harness-coder.md`** — new `## Editing Discipline` section. The coder agent ships with `Bash` in its tool list and previously had no rule on *how* to edit files, so it could (and did) edit source by shelling out to `python3`/`sed`/`awk` heredocs that splice a file by string offset. That bypasses the `post-edit-wrapper.sh` PostToolUse hook (layer-boundary checks never run), leaves no reviewable diff, and corrupts the file when whitespace shifts. The new section requires the `Edit`/`Write` tools and bans shell-splicing.
+- **`scripts/migrate-v0.5.2-to-v0.5.3.sh`** — new. `harness-coder.md` is written per-project at `/espalier-init` time, so a plugin update never reaches an existing install. This script appends the `## Editing Discipline` section to `espalier/agents/harness-coder.md` in an existing repo. Idempotent, `--dry-run`/`--yes` flags, pure bash.
+- **`skills/espalier-migrate/SKILL.md`** — `/espalier-migrate` now detects when the coder-agent patch is needed (content check on `harness-coder.md`) and applies `migrate-v0.5.2-to-v0.5.3.sh` as the final step of the chain.
+
+No behavior change for fresh `/espalier-init` runs beyond the new agent rule.
+
 ## 0.5.2 — 2026-05-22
 
 Patch: the `core.hooksPath` fix from v0.5.1 extended to the migration scripts.

--- a/scripts/migrate-v0.5.2-to-v0.5.3.sh
+++ b/scripts/migrate-v0.5.2-to-v0.5.3.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Migrate an Espalier v0.5.0 / v0.5.1 / v0.5.2 target repo to v0.5.3.
+#
+# Run from the TARGET project root. Idempotent. Safe to re-run.
+# Use --dry-run to preview before applying.
+#
+# v0.5.3 adds an "Editing Discipline" section to the coder sub-agent
+# (espalier/agents/harness-coder.md): it forbids the coder from editing files
+# by shelling out to python3/sed/awk heredocs, which bypass the
+# post-edit-wrapper.sh boundary hook and leave no reviewable diff.
+#
+# harness-coder.md is written per-project at /espalier-init time, so a plugin
+# update never reaches an existing install — this script does.
+#
+# Usage: bash migrate-v0.5.2-to-v0.5.3.sh [--dry-run] [--yes]
+
+set -u
+
+DRY_RUN=no
+SKIP_PROMPT=no
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=yes ;;
+    --yes)     SKIP_PROMPT=yes ;;
+    -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown flag: $arg (use --help)" >&2; exit 2 ;;
+  esac
+done
+
+log() { echo "[migrate-v0.5.3] $*"; }
+
+AGENT="espalier/agents/harness-coder.md"
+MARKER="## Editing Discipline"
+
+# --- Preflight --------------------------------------------------------------
+if [ -d "harness" ] && [ ! -d "espalier" ]; then
+  echo "ERROR: pre-v0.4 install detected (harness/ directory)." >&2
+  echo "Run /espalier-migrate first to apply the v0.1->v0.5 chain, then re-run." >&2
+  exit 1
+fi
+if [ ! -f "$AGENT" ]; then
+  echo "ERROR: $AGENT not found — run this from the target project root." >&2
+  exit 1
+fi
+
+# --- Idempotency ------------------------------------------------------------
+if grep -qF "$MARKER" "$AGENT"; then
+  log "$AGENT already has the Editing Discipline section — nothing to do."
+  exit 0
+fi
+
+# --- The section to append --------------------------------------------------
+emit_section() {
+cat << 'EOF'
+
+## Editing Discipline
+
+Modify files with the `Edit` tool (exact-string replacement); create new files
+with `Write`. NEVER edit a file by shelling out — no `python3` / `sed` / `awk`
+heredocs that read a file, splice it by string offset, and write it back.
+
+Shell-splicing is banned because it:
+- bypasses the `post-edit-wrapper.sh` PostToolUse hook, so the layer-boundary
+  check never runs on the change;
+- leaves no reviewable diff for the reviewer agent — just an opaque file write;
+- relies on brittle literal offsets (`str.index`) that silently corrupt the
+  file when whitespace or surrounding code shifts.
+
+For a structural change `Edit` cannot express cleanly, use a real codemod for
+the language (e.g. ts-morph / jscodeshift for TS/JS) — not a hand-rolled
+string splice.
+EOF
+}
+
+if [ "$DRY_RUN" = "yes" ]; then
+  log "[dry-run] would append the Editing Discipline section to $AGENT:"
+  emit_section | sed 's/^/  | /'
+  exit 0
+fi
+
+# --- Confirm ----------------------------------------------------------------
+if [ "$SKIP_PROMPT" != "yes" ]; then
+  ANS=""
+  printf 'Append the Editing Discipline section to %s? [y/N] ' "$AGENT"
+  read -r ANS || true
+  case "$ANS" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted — nothing changed."; exit 0 ;;
+  esac
+fi
+
+# --- Apply ------------------------------------------------------------------
+# Ensure a trailing newline so the appended heading is not glued to the last line.
+if [ -n "$(tail -c1 "$AGENT" 2>/dev/null)" ]; then
+  echo >> "$AGENT"
+fi
+emit_section >> "$AGENT"
+log "Appended the Editing Discipline section to $AGENT"
+
+# --- Verify -----------------------------------------------------------------
+if grep -qF "$MARKER" "$AGENT" && grep -qF "post-edit-wrapper.sh" "$AGENT"; then
+  log "Verification: 1/1 check passed"
+  exit 0
+else
+  echo "ERROR: verification failed — '$MARKER' not found in $AGENT after append." >&2
+  exit 1
+fi

--- a/skills/espalier-init/templates/agents/harness-coder.md
+++ b/skills/espalier-init/templates/agents/harness-coder.md
@@ -66,3 +66,20 @@ Do NOT set this signal if you can write a meaningful test within the original fi
 - Skip the build/lint check
 - Modify files outside the task scope
 - Add features not in the requirements
+
+## Editing Discipline
+
+Modify files with the `Edit` tool (exact-string replacement); create new files
+with `Write`. NEVER edit a file by shelling out — no `python3` / `sed` / `awk`
+heredocs that read a file, splice it by string offset, and write it back.
+
+Shell-splicing is banned because it:
+- bypasses the `post-edit-wrapper.sh` PostToolUse hook, so the layer-boundary
+  check never runs on the change;
+- leaves no reviewable diff for the reviewer agent — just an opaque file write;
+- relies on brittle literal offsets (`str.index`) that silently corrupt the
+  file when whitespace or surrounding code shifts.
+
+For a structural change `Edit` cannot express cleanly, use a real codemod for
+the language (e.g. ts-morph / jscodeshift for TS/JS) — not a hand-rolled
+string splice.

--- a/skills/espalier-migrate/SKILL.md
+++ b/skills/espalier-migrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: espalier-migrate
-description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5 you need and applies them in order.
+description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5, and the v0.5.3 coder-agent patch you need and applies them in order.
 ---
 
 # Espalier Migration Runner
@@ -13,12 +13,12 @@ description: Migrate an existing harness/espalier install to the current Espalie
 
 ## When NOT to Use
 - Fresh project with no existing `harness/` or `espalier/` dir → use `/espalier-init` instead.
-- Already on v0.5.0 (`espalier/hooks/drift-detect.sh` + `espalier/.doctor-cadence` present) → no migration needed.
+- Already fully up to date — `/espalier-migrate` detects this itself and exits cleanly with no changes.
 
 ## Instructions
 
 You are running a migration of an existing install to the current Espalier
-version. Up to THREE migrations may apply, always in this order:
+version. Up to FOUR migrations may apply, always in this order:
 
 1. **v0.1.x → v0.2.x** — typed `harness/changes/{type}/{slug}/` layout,
    `/harness-fix` lane, squash-merge decision. Mechanical:
@@ -29,10 +29,14 @@ version. Up to THREE migrations may apply, always in this order:
 3. **v0.4.x → v0.5.0** — doc-drift detection: drift hooks, the
    `/espalier-prune` + `/espalier-doctor` skills, the post-merge dispatcher,
    `.doctor-cadence`. Mechanical: `scripts/migrate-v0.4-to-v0.5.sh`.
+4. **v0.5.0–v0.5.2 → v0.5.3** — appends the `## Editing Discipline` section to
+   the coder sub-agent (`espalier/agents/harness-coder.md`). Mechanical:
+   `scripts/migrate-v0.5.2-to-v0.5.3.sh`.
 
 Your job: detect which one(s) apply, locate the scripts, preview, get
-confirmation, apply in order. A v0.1.x install needs ALL THREE; a v0.3.x
-install needs the last two; a v0.4.x install needs only the last.
+confirmation, apply in order. A v0.1.x install needs ALL FOUR; a v0.3.x
+install needs the last three; a v0.4.x install needs the last two; a
+v0.5.0–v0.5.2 install needs only the v0.5.3 patch.
 
 ### Step 1: Preflight + detect install version
 
@@ -42,6 +46,7 @@ Run from the current working directory (must be the target project root):
 NEEDS_V01_V02=no
 NEEDS_V03_V04=no
 NEEDS_V04_V05=no
+NEEDS_V05_PATCH=no
 
 if [ ! -d "harness" ] && [ ! -d "espalier" ]; then
   echo "ERROR: no harness/ or espalier/ dir found — not a target install."
@@ -56,13 +61,23 @@ if [ -d "harness" ]; then
   fi
   NEEDS_V03_V04=yes          # harness/ always needs the rename
   NEEDS_V04_V05=yes          # ...then the doc-drift upgrade
+  NEEDS_V05_PATCH=yes        # ...then the v0.5.3 coder-agent patch
 elif [ -d "espalier" ]; then
-  # Already renamed — distinguish v0.4.x from v0.5.0.
-  if [ -f "espalier/hooks/drift-detect.sh" ] && [ -f "espalier/.doctor-cadence" ]; then
-    echo "Already on v0.5.0. Nothing to do."
-    exit 0
+  # Already renamed. v0.4.x still needs the doc-drift upgrade.
+  if [ ! -f "espalier/hooks/drift-detect.sh" ] || [ ! -f "espalier/.doctor-cadence" ]; then
+    NEEDS_V04_V05=yes        # v0.4.x → doc-drift upgrade
   fi
-  NEEDS_V04_V05=yes          # v0.4.x → doc-drift upgrade
+  # v0.5.3: harness-coder.md gains an "## Editing Discipline" section. It is a
+  # per-project file, so a plugin update never reaches an existing install.
+  if ! grep -qF "## Editing Discipline" espalier/agents/harness-coder.md 2>/dev/null; then
+    NEEDS_V05_PATCH=yes
+  fi
+fi
+
+if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
+   && [ "$NEEDS_V04_V05" = no ] && [ "$NEEDS_V05_PATCH" = no ]; then
+  echo "Already fully up to date. Nothing to do."
+  exit 0
 fi
 ```
 
@@ -82,7 +97,7 @@ for candidate in \
   "$HOME/repos/harness-engineering" \
   "$HOME/SBM_Projects/espalier-engineering" \
   "$HOME/SBM_Projects/harness-engineering"; do
-  if [ -f "$candidate/scripts/migrate-v0.4-to-v0.5.sh" ]; then
+  if [ -f "$candidate/scripts/migrate-v0.5.2-to-v0.5.3.sh" ]; then
     PLUGIN_DIR="$candidate"
     break
   fi
@@ -96,7 +111,7 @@ if [ -z "$PLUGIN_DIR" ]; then
 fi
 ```
 
-If `migrate-v0.4-to-v0.5.sh` is missing but older scripts exist, the plugin
+If `migrate-v0.5.2-to-v0.5.3.sh` is missing but older scripts exist, the plugin
 itself is out of date — tell the user to `/plugin update espalier-engineering`
 first.
 
@@ -109,6 +124,7 @@ verbatim:
 [ "$NEEDS_V01_V02" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.1-to-v0.2.sh" --dry-run --plugin-dir="$PLUGIN_DIR/skills/espalier-init"
 [ "$NEEDS_V03_V04" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.3-to-v0.4.sh" --dry-run
 [ "$NEEDS_V04_V05" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.4-to-v0.5.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
+[ "$NEEDS_V05_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.5.2-to-v0.5.3.sh" --dry-run
 ```
 
 ### Step 4: If v0.4→v0.5 applies, pick the doctor cadence
@@ -151,6 +167,7 @@ completed.
 [ "$NEEDS_V01_V02" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.1-to-v0.2.sh" --yes
 [ "$NEEDS_V03_V04" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.3-to-v0.4.sh" --yes
 [ "$NEEDS_V04_V05" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.4-to-v0.5.sh" --yes --plugin-dir="$PLUGIN_DIR" --doctor-cadence="$DOCTOR_CADENCE"
+[ "$NEEDS_V05_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.5.2-to-v0.5.3.sh" --yes
 ```
 
 Each script's verification block prints `X passed, Y failed`. Surface every
@@ -213,6 +230,13 @@ Migration applied. Recommended next steps:
 | `--yes` | Skip apply confirmation prompt |
 | `--doctor-cadence=<val>` | `/espalier-doctor` cadence: `every-change\|weekly\|monthly\|manual` (default `weekly`) |
 | `--plugin-dir=<path>` | Path to the espalier-engineering plugin checkout |
+
+**v0.5.2→v0.5.3 (`migrate-v0.5.2-to-v0.5.3.sh`):**
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Show the section that would be appended |
+| `--yes` | Skip the apply confirmation prompt |
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Summary

Gives the `harness-coder` sub-agent an explicit `## Editing Discipline` rule — use the `Edit`/`Write` tools, never edit files by shelling out to `python3`/`sed`/`awk` heredocs — and ships a migration that adds the rule to existing installs.

## Why

The coder sub-agent ships with `Bash` in its `tools:` list and `harness-coder.md` carried **no rule on *how* to edit files**. So the coder could (and in practice did) edit source by shelling out:

```bash
python3 - <<'PY'
s = open("backend/lib/pdf-renderer/sections/BodyPage.tsx").read()
start = s.index("      <View\n        fixed")
end = s.index("/>", start) + 2
...
```

That string-splice approach:
- **bypasses `post-edit-wrapper.sh`** — the PostToolUse hook fires on `Edit`/`Write`, not on `Bash`, so Espalier's layer-boundary check never runs on the change;
- leaves **no reviewable diff** for the reviewer agent — just an opaque whole-file rewrite;
- relies on **brittle literal offsets** (`str.index` on whitespace-exact anchors) that silently corrupt the file when Prettier or surrounding code shifts.

## Changes

- **`skills/espalier-init/templates/agents/harness-coder.md`** — new `## Editing Discipline` section: requires `Edit`/`Write`, bans shell-splicing, points at real codemods (ts-morph / jscodeshift) for structural edits. Fixes *future* `/espalier-init` runs.
- **`scripts/migrate-v0.5.2-to-v0.5.3.sh`** — new. `harness-coder.md` is written per-project at init time, so a plugin update never reaches an existing install. This script appends the section to `espalier/agents/harness-coder.md`. Idempotent (content grep-guard), pure bash, `--dry-run`/`--yes`, refuses pre-v0.4 (`harness/`) installs.
- **`skills/espalier-migrate/SKILL.md`** — `/espalier-migrate` is now a four-stage chain; it detects when the coder-agent patch is needed (content check on `harness-coder.md`) and runs `migrate-v0.5.2-to-v0.5.3.sh` last.
- **Release** — CHANGELOG.md 0.5.3 entry; `plugin.json` + `marketplace.json` bumped 0.5.2 → 0.5.3.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (fix or feature that changes existing skill/script behavior)
- [ ] Docs only
- [ ] Refactor / cleanup (no behavior change)

## Test plan

- [x] `bash -n` on `migrate-v0.5.2-to-v0.5.3.sh` under `/bin/bash` (macOS 3.2.57) — pass
- [x] Migration script tested against synthetic v0.5.x install fixtures — dry-run (no-op), apply, **idempotent re-run**, byte-identical-to-template parity, error cases (missing file, `harness/` install). **12/12**, see below. (System bash only — not re-run under homebrew bash.)
- [x] `espalier-migrate/SKILL.md` — every `bash` block extracted and `bash -n`'d — pass
- [x] `bash scripts/test-bootstrap.sh` — **51/51**, no regression (bootstrap untouched)
- [ ] Spawned a test project + ran `/espalier-init` — **not run**; the template change is verified by the parity check (migrate output is byte-identical to the template section)
- [x] CHANGELOG.md updated under the next version heading
- [x] Tested on macOS / Linux: **macOS** (Darwin 25.5.0, system bash 3.2)

## Compatibility

- [x] Pure additive — no impact on existing installs
- [ ] Additive — backward-compat fallback retained for v0.3 / v0.2 installs
- [ ] Breaking — migration shim added

The migration only **appends** a section. Existing installs are untouched until the user runs `/espalier-migrate`. Fresh inits get the rule directly.

## Screenshots / output

```
### apply + idempotency
  OK   apply (--yes) exits 0
  OK   section now present
  OK   section names post-edit-wrapper
  OK   section bans shelling out
  OK   re-run idempotent (line count stable: 27==27)
  OK   migrate section == template section (byte-identical)
### error cases
  OK   no harness-coder.md → non-zero exit
  OK   pre-v0.4 (harness/) install → non-zero exit
### espalier-migrate SKILL.md — bash blocks syntax-check
  OK   all SKILL.md bash blocks parse (bash -n)

  passed: 12   failed: 0
```

## Reviewer notes

- **`migrate-v0.5.2-to-v0.5.3.sh` is pure bash** — appends the section to EOF with a `cat` heredoc, no `python`/`sed` splice. Deliberate: a script that ships the "don't shell-splice" rule shouldn't itself shell-splice. Append-to-EOF is also simpler and safer than anchor-insertion for a single section.
- `migrate-v0.4-to-v0.5.sh` *does* patch files via a `python3` heredoc — that is fine and out of scope here. The new rule governs the **coder agent editing a project's source code**, not migration tooling (which is reviewed as scripts and isn't subject to the post-edit hook).
- Template and migration produce **byte-identical** sections — the e2e diff-checks this, so the two cannot drift apart silently.
- `/espalier-migrate` detection is **content-based** (`grep "## Editing Discipline"`) — v0.5.0–v0.5.3 installs are structurally identical, so a structural probe cannot tell them apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
