### PR TITLE
fix: resolve the plugin dir from ${CLAUDE_SKILL_DIR}, not path guesses

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Zayhan"
   },
   "description": "Marketplace publishing the Espalier Engineering plugin — auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -13,7 +13,7 @@
         "repo": "Junhanliu-dev/espalier-engineering"
       },
       "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
   "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": {
     "name": "Zayhan"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.4 — 2026-05-22
+
+Patch: skills resolve their own plugin directory instead of guessing paths.
+
+- **`skills/espalier-migrate/SKILL.md`** — Step 2 located the plugin scripts with a hard-coded list of guessed paths (`~/.claude/plugins/<name>`, `~/repos/...`, `~/SBM_Projects/...`). None matched Claude Code's actual marketplace layout (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`), so `/espalier-migrate` either failed outright for a normal install, or — if a same-named dev checkout happened to sit in `$HOME` — silently ran *that* checkout's scripts instead of the installed plugin. It now derives the plugin root from `${CLAUDE_SKILL_DIR}` (the skill's own directory, set by Claude Code), which resolves the installed plugin in every layout.
+- **`skills/espalier-init/SKILL.md`** — Phase 3 invoked `bootstrap-espalier.sh` through `$PLUGIN_DIR`, a variable the skill never defined. It now uses `${CLAUDE_SKILL_DIR}` for both the script path and bootstrap's `--plugin-dir`.
+
+`${CLAUDE_PLUGIN_ROOT}` is not available to skill-spawned Bash — `${CLAUDE_SKILL_DIR}` is the documented mechanism. An `ESPALIER_PLUGIN_DIR` override plus a dev-checkout fallback remain for the rare case the variable is unset.
+
 ## 0.5.3 — 2026-05-22
 
 Patch: the coder sub-agent gets an explicit editing-discipline rule.

--- a/skills/espalier-init/SKILL.md
+++ b/skills/espalier-init/SKILL.md
@@ -266,9 +266,13 @@ Spec template (`templates/skills/espalier-coding-spec.md`) has **no frontmatter*
 
 Run:
 ```bash
-bash $PLUGIN_DIR/scripts/bootstrap-espalier.sh \
+# ${CLAUDE_SKILL_DIR} is this skill's directory (<plugin>/skills/espalier-init).
+# bootstrap-espalier.sh sits at the plugin root (../../scripts/); its
+# --plugin-dir wants the dir holding hook-templates/ + templates/ — which is
+# this skill's own directory. Resolves the installed plugin in any layout.
+bash "${CLAUDE_SKILL_DIR}/../../scripts/bootstrap-espalier.sh" \
   --project-dir=. \
-  --plugin-dir=$PLUGIN_DIR \
+  --plugin-dir="${CLAUDE_SKILL_DIR}" \
   --lang=$LANG \
   --merge-decision=$MERGE_DECISION \
   --doctor-cadence=$DOCTOR_CADENCE

--- a/skills/espalier-migrate/SKILL.md
+++ b/skills/espalier-migrate/SKILL.md
@@ -85,35 +85,44 @@ Report the detected plan to the user (which migration(s) will run).
 
 ### Step 2: Locate migration scripts
 
-Search common plugin install paths for the plugin root (contains `scripts/`):
+The skill resolves its own plugin root — no path guessing. `${CLAUDE_SKILL_DIR}`
+is set by Claude Code to the directory of the running skill
+(`<plugin>/skills/espalier-migrate`); the plugin root, where `scripts/` lives,
+is two levels up. This resolves the *installed* plugin in every layout —
+marketplace cache (`~/.claude/plugins/cache/...`), dev checkout, or symlink —
+never a stray `$HOME` checkout that merely shares the name.
 
 ```bash
 PLUGIN_DIR=""
-for candidate in \
-  "$HOME/.claude/plugins/espalier-engineering" \
-  "$HOME/.claude/plugins/espalier" \
-  "$HOME/.claude/plugins/harness-engineering" \
-  "$HOME/repos/espalier-engineering" \
-  "$HOME/repos/harness-engineering" \
-  "$HOME/SBM_Projects/espalier-engineering" \
-  "$HOME/SBM_Projects/harness-engineering"; do
-  if [ -f "$candidate/scripts/migrate-v0.5.2-to-v0.5.3.sh" ]; then
-    PLUGIN_DIR="$candidate"
-    break
-  fi
-done
+# Primary: derive the plugin root from the skill's own location.
+if [ -n "${CLAUDE_SKILL_DIR:-}" ] \
+   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.5.2-to-v0.5.3.sh" ]; then
+  PLUGIN_DIR="$(cd "${CLAUDE_SKILL_DIR}/../.." && pwd)"
+fi
+
+# Fallback (rare — e.g. CLAUDE_SKILL_DIR unset): explicit override, then a
+# known dev-checkout location.
+if [ -z "$PLUGIN_DIR" ]; then
+  for candidate in "${ESPALIER_PLUGIN_DIR:-}" "$HOME/SBM_Projects/espalier-engineering"; do
+    [ -n "$candidate" ] || continue
+    if [ -f "$candidate/scripts/migrate-v0.5.2-to-v0.5.3.sh" ]; then
+      PLUGIN_DIR="$candidate"
+      break
+    fi
+  done
+fi
 
 if [ -z "$PLUGIN_DIR" ]; then
-  echo "ERROR: couldn't find Espalier plugin scripts in standard locations." >&2
-  echo "Update the plugin first: /plugin update espalier-engineering" >&2
+  echo "ERROR: couldn't locate the Espalier plugin." >&2
+  echo "If it is installed, update it: /plugin update espalier-engineering" >&2
   echo "Or set ESPALIER_PLUGIN_DIR to your espalier-engineering checkout." >&2
   exit 1
 fi
 ```
 
-If `migrate-v0.5.2-to-v0.5.3.sh` is missing but older scripts exist, the plugin
-itself is out of date — tell the user to `/plugin update espalier-engineering`
-first.
+If the primary path misses and the fallback fires, the plugin install is
+likely stale (no `migrate-v0.5.2-to-v0.5.3.sh`) — tell the user to
+`/plugin update espalier-engineering` first.
 
 ### Step 3: Show dry-run preview for each applicable migration
 


### PR DESCRIPTION
## Summary

`/espalier-migrate` and `/espalier-init` now locate their plugin's bundled scripts via `${CLAUDE_SKILL_DIR}` — the skill's own directory — instead of guessing a list of `$HOME` paths that never matched Claude Code's real install layout.

## Why

`espalier-migrate` Step 2 resolved the plugin root with a hard-coded candidate list: `~/.claude/plugins/<name>`, `~/repos/...`, `~/SBM_Projects/...`. Claude Code installs marketplace plugins to `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` — **not on that list**. Result:

- **Normal install** (marketplace, no dev checkout): every candidate misses → `ERROR: couldn't find Espalier plugin scripts` → `/espalier-migrate` is unusable, even though the plugin is installed and current.
- **Developer machine** (a same-named checkout sits in `$HOME`): the list matched `~/SBM_Projects/espalier-engineering` — the **dev checkout** — and ran *its* scripts instead of the installed plugin. Observed in a real run:
  ```
  PLUGIN_DIR=/Users/junhanliu/SBM_Projects/espalier-engineering
  Note: plugin script source was ~/SBM_Projects/... (local checkout), not the cache plugin
  ```

A skill should not guess where it lives. `${CLAUDE_SKILL_DIR}` is set by Claude Code to the running skill's directory and is the documented way to reach bundled files. (`${CLAUDE_PLUGIN_ROOT}` — my first guess — is **not** available to skill-spawned Bash; confirmed against the Claude Code skills docs.)

## Changes

- **`skills/espalier-migrate/SKILL.md`** — Step 2 derives `PLUGIN_DIR` from `${CLAUDE_SKILL_DIR}/../..` (skill dir → plugin root). Fallback retained: `ESPALIER_PLUGIN_DIR` override, then a dev-checkout path, for the rare case the variable is unset.
- **`skills/espalier-init/SKILL.md`** — Phase 3 invoked `bootstrap-espalier.sh` through `$PLUGIN_DIR`, **a variable the skill never defined**. Now uses `${CLAUDE_SKILL_DIR}` for the script path (`../../scripts/`) and bootstrap's `--plugin-dir` (the skill dir itself — it holds `hook-templates/` + `templates/`, which is what bootstrap validates).
- **Release** — CHANGELOG.md 0.5.4 entry; `plugin.json` + `marketplace.json` bumped 0.5.3 → 0.5.4.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (fix or feature that changes existing skill/script behavior)
- [ ] Docs only
- [ ] Refactor / cleanup (no behavior change)

## Test plan

- [x] Both changed bash blocks extracted from the SKILL.md files and `bash -n`'d — pass
- [x] Focused e2e — **11/11**: `${CLAUDE_SKILL_DIR}` → plugin root; `ESPALIER_PLUGIN_DIR` fallback; error path when nothing resolves; `espalier-init` Phase 3 invocation run in `--dry-run` against a temp repo (exit 0, no `--plugin-dir not found`). Output below.
- [x] `bash scripts/test-bootstrap.sh` — **51/51**, no regression (no script touched)
- [ ] Full `/espalier-migrate` + `/espalier-init` end-to-end — **not run**; changes are confined to two SKILL.md bash blocks, verified by extracting and running them with the real env var
- [x] CHANGELOG.md updated under the next version heading
- [x] Tested on macOS / Linux: **macOS** (Darwin 25.5.0, system bash 3.2)

## Compatibility

- [x] Pure additive — no impact on existing installs
- [ ] Additive — backward-compat fallback retained for v0.3 / v0.2 installs
- [ ] Breaking — migration shim added

A correctly-installed plugin is unaffected — it just resolves *correctly* now. The one behavior change: on a developer machine, `/espalier-migrate` now prefers the **installed** plugin over a `$HOME` dev checkout. A developer who wants the checkout can set `ESPALIER_PLUGIN_DIR`.

## Screenshots / output

```
### espalier-migrate Step 2 — PLUGIN_DIR resolution
  OK   CLAUDE_SKILL_DIR set → resolves to plugin root
  OK   fallback: ESPALIER_PLUGIN_DIR → resolves
  OK   no var, no override, no checkout → errors (exit 1)
### espalier-init Phase 3 — bootstrap via ${CLAUDE_SKILL_DIR}
  OK   bootstrap resolves via ../../scripts
  OK   --plugin-dir target holds hook-templates/
  OK   Phase 3 invocation runs (exit 0)
  OK   no '--plugin-dir not found' error
  OK   dry-run produced bootstrap output

  passed: 11   failed: 0
```

## Reviewer notes

- `${CLAUDE_SKILL_DIR}` points at the **skill subdirectory** (`<plugin>/skills/<skill>`), not the plugin root — hence `../..` to reach `scripts/`. For `espalier-init`, the skill dir *is* what bootstrap's `--plugin-dir` wants (it holds `hook-templates/`), so no `../..` there.
- `espalier-init`'s `$PLUGIN_DIR` was genuinely undefined — this fixes a latent bug, not just a cosmetic one.
- The marketplace cache path (`~/.claude/plugins/cache/...`) is deliberately **not** hard-coded — the Claude Code docs don't promise it as stable API. `${CLAUDE_SKILL_DIR}` is the supported contract.
- Other skills (`espalier`, `espalier-fix`, `espalier-doctor`, `espalier-prune`) were checked — none path-guess for the plugin dir; they reference `espalier/` paths inside the target project, which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
