### PR TITLE
optimize espalier-grill: coverage guard + tier-override (darwin pass, 87→91)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 SKILL.original.md
 __pycache__/
 .in_use/
+eval/grill/*-run.log

--- a/eval/grill/README.md
+++ b/eval/grill/README.md
@@ -10,10 +10,12 @@ it catches whether grill actually surfaces ambiguity, and scores question qualit
 
 ```
 eval/grill/
-├── README.md      this file
-├── rubric.md      how a grill run is scored
-├── run.sh         the runner
-└── fixtures/      golden requirement/bug fixtures with planted ambiguities
+├── README.md          this file
+├── rubric.md          how a grill run is scored
+├── run.sh             the runner (all + shadow + non-shadow catch-rate)
+├── validate-judge.sh  judge-vs-human agreement harness (rubric.md "Judge validation")
+├── judge-validation/  generated: transcripts + hand-score sheet (created on demand)
+└── fixtures/          golden requirement/bug fixtures with planted ambiguities
 ```
 
 ## Run
@@ -26,6 +28,23 @@ Per fixture the runner: (1) runs `espalier-grill` against the fixture via `claud
 headless, playing the fixture's `answer_script` as the simulated user; (2) scores
 the transcript with an LLM judge against `rubric.md`; (3) aggregates. Exits non-zero
 if the catch-rate is below the gate (0.80 — plan §9).
+
+It reports three catch-rates: **all**, **shadow**, and **non-shadow**. The shadow
+number is the trustworthy one (see "Shadow subset" below). When shadow fixtures exist
+they must ALSO clear the gate — a high all-fixtures rate carried by author-written
+non-shadow fixtures does not pass. When no shadow fixtures exist the gate is flagged
+PROVISIONAL.
+
+## Validate the judge first
+
+```bash
+bash eval/grill/validate-judge.sh generate   # grill+judge a 6-fixture subset
+# ...read judge-validation/transcripts/*, fill human_score in judge-validation/handscore.tsv...
+bash eval/grill/validate-judge.sh compare     # agreement vs judge; gate >= 0.75
+```
+
+The catch-rate is only as trustworthy as the judge producing it. Run this before
+trusting `run.sh`'s numbers, and re-run whenever `rubric.md` changes.
 
 ## Fixture format
 
@@ -49,12 +68,16 @@ shadow: false
 
 ## Discipline
 
-- **Reach 20–30 fixtures.** This seed set has 9 (3 per tier). The gate is provisional
-  until the set is full — plan §6 Phase A2.
+- **Reach 20–30 fixtures.** Currently 19 (9 seed + 10 shadow). Add a handful more to
+  clear the 20 floor — plan §6 Phase A2.
 - **Shadow subset.** Roughly one third of fixtures should be `shadow: true` — authored
   from real tickets or by someone other than the grill-skill author, so the skill
-  cannot be tuned to pass known fixtures. The current seed is all `shadow: false`: it
-  was written alongside the skill and is NOT a valid shadow set.
+  cannot be tuned to pass known fixtures. The 10 shadow fixtures were built from real
+  CNE (`portal.cneaustralia.com.au`) and OCV (`ocv-dashboard`) commit history: the raw
+  commit subject is the ambiguous input, and the answer key is derived from what the
+  commit's diff *actually* decided — so the key reflects real resolution, not the
+  skill author's intuition. The 9 seed fixtures remain `shadow: false` (written
+  alongside the skill). Shadow fraction is currently 53%.
 - **Validate the judge** before trusting it — see `rubric.md` "Judge validation"
   (≥ 75% agreement with hand scores).
 - **Regression gate.** Run `run.sh` on every `espalier-grill.md` edit; prompt edits

--- a/eval/grill/auto-optimize-results.tsv
+++ b/eval/grill/auto-optimize-results.tsv
@@ -1,0 +1,4 @@
+timestamp	commit	skill	old_score	new_score	status	dimension	note	eval_mode
+2026-07-07T10:45	baseline	espalier-grill	-	87.0	baseline	-	 catch-rate 0.93 all PASS	full_test
+2026-07-07T10:59	18c14a3	espalier-grill	87.0	89.3	keep	边界条件	coverage guard+non-answer; catch 0.93->0.96 full-02 1.00	full_test
+2026-07-07T11:10	70accd8	espalier-grill	89.3	91.2	keep	检查点	tier-override; catch 0.96->1.00 all coverage 1.0	full_test

--- a/eval/grill/fixtures/full-01-dashboard-faster.md
+++ b/eval/grill/fixtures/full-01-dashboard-faster.md
@@ -19,6 +19,8 @@ answer_script:
     reply: failed data-fetch calls to the metrics API
   - asks_about: better error handling
     reply: show a retry button instead of a blank panel
+  - asks_about: whose experience / actor
+    reply: end users viewing the dashboard (SBM staff), on initial page load
   - asks_about: scope boundary
     reply: load time and fetch errors only — no redesign
 shadow: false

--- a/eval/grill/fixtures/shadow-full-01-order-issue.md
+++ b/eval/grill/fixtures/shadow-full-01-order-issue.md
@@ -1,0 +1,25 @@
+---
+fixture_id: shadow-full-01-order-issue
+mode: diagnosis
+expected_tier: full
+expected_signals: 5
+planted_ambiguities:
+  - '"order" is undefined — sort order? tab order? array/list order? of what?'
+  - no symptom, no actor, no location — where does the wrong order show?
+  - root cause asserted as an "issue" with zero evidence
+  - no reproduction steps
+  - scope unstated — frontend UI, backend, PDF?
+answer_script:
+  - asks_about: order of what
+    reply: the Fire Cause section's field list — Area of Origin, Point of Origin, First Fuel, Ignition Source
+  - asks_about: what specifically is wrong
+    reply: Point of Origin renders before First Fuel; it should come after First Fuel
+  - asks_about: where it manifests
+    reply: two places disagree — the admin Settings dropdown config and the Analysis build-order UI are out of sync
+  - asks_about: root cause
+    reply: the two UI config arrays list the fields in different orders; neither is a backend/data problem
+  - asks_about: scope boundary
+    reply: frontend list-config only — no backend, schema, or PDF ordering changes
+shadow: true
+---
+fix: order issue

--- a/eval/grill/fixtures/shadow-full-02-decimal-points.md
+++ b/eval/grill/fixtures/shadow-full-02-decimal-points.md
@@ -1,0 +1,25 @@
+---
+fixture_id: shadow-full-02-decimal-points
+mode: diagnosis
+expected_tier: full
+expected_signals: 5
+planted_ambiguities:
+  - '"decimal points" on which fields / which screen?'
+  - no symptom — what actually goes wrong today?
+  - is it a display/rounding bug or an input-entry bug? (unconfirmed cause)
+  - no reproduction steps
+  - unstated scope and edge behaviour (when should formatting apply?)
+answer_script:
+  - asks_about: which fields
+    reply: the money inputs — gross amount, super, and GST — on the working-project row
+  - asks_about: what actually breaks
+    reply: typing "100." or a trailing zero gets clobbered back to "100" mid-edit; you can't enter a decimal
+  - asks_about: display bug or input bug
+    reply: input-entry bug — the field is bound straight to the numeric value, so reparsing overwrites what you're typing
+  - asks_about: when to normalise to 2 decimals
+    reply: on blur only, never while typing
+  - asks_about: scope
+    reply: just the working-project row component; don't touch the store or the currency-parse helper
+shadow: true
+---
+fix: add decimal points

--- a/eval/grill/fixtures/shadow-full-03-builder-history.md
+++ b/eval/grill/fixtures/shadow-full-03-builder-history.md
@@ -1,0 +1,25 @@
+---
+fixture_id: shadow-full-03-builder-history
+mode: diagnosis
+expected_tier: full
+expected_signals: 5
+planted_ambiguities:
+  - single bare noun "builderHistory" — no symptom stated at all
+  - no actor, no trigger — what operation fails?
+  - root cause entirely unstated
+  - no reproduction
+  - fix approach and scope unstated (schema? app code? data migration?)
+answer_script:
+  - asks_about: symptom
+    reply: creating a BuilderHistory row fails with a unique-constraint violation
+  - asks_about: which fields
+    reply: companyId and xeroId are both marked @unique on the BuilderHistory model
+  - asks_about: why that is wrong
+    reply: one builder legitimately has many history snapshots that share the same companyId — uniqueness is too strict here
+  - asks_about: preserve lookup performance
+    reply: yes — replace each @unique with an @@index on the same field
+  - asks_about: scope / data migration
+    reply: schema.prisma only; no data backfill and no application-code change
+shadow: true
+---
+fix: builderHistory

--- a/eval/grill/fixtures/shadow-light-01-remove-telephone.md
+++ b/eval/grill/fixtures/shadow-light-01-remove-telephone.md
@@ -1,0 +1,19 @@
+---
+fixture_id: shadow-light-01-remove-telephone
+mode: spec
+expected_tier: light
+expected_signals: 3
+planted_ambiguities:
+  - '"telephone" is ambiguous — there are two phone fields (tel vs phone); which one?'
+  - scope unstated — frontend only, or backend schema/column too?
+  - how far it reaches (which forms / transformers) is unsaid
+answer_script:
+  - asks_about: which phone field
+    reply: the `tel` field specifically — `phone` stays as the sole phone-number field
+  - asks_about: backend / schema too
+    reply: no, frontend contractor-onboarding flow only; leave the DB column in place
+  - asks_about: which touchpoints
+    reply: the contact-info form, the review summary row, the zod schema/defaults, and all the onboarding data transformers
+shadow: true
+---
+feat: remove telephone from existence

--- a/eval/grill/fixtures/shadow-light-02-invoice-failures.md
+++ b/eval/grill/fixtures/shadow-light-02-invoice-failures.md
@@ -1,0 +1,19 @@
+---
+fixture_id: shadow-light-02-invoice-failures
+mode: diagnosis
+expected_tier: light
+expected_signals: 3
+planted_ambiguities:
+  - root cause of the false success is unstated — why does a failure show success?
+  - batch behaviour undefined — one card fails vs the whole batch?
+  - partial-failure behaviour and which error message to show are unspecified
+answer_script:
+  - asks_about: why it falsely succeeds
+    reply: the success toast lives in a `finally` block, so it fires even when the invoice mutation throws
+  - asks_about: batch semantics
+    reply: a shared builder-contact error fails every card in that batch together; per-card errors come back as individual results
+  - asks_about: partial failures
+    reply: show "N of M invoice(s) failed" and still commit the cards that did succeed; on a total failure show the first failure's message
+shadow: true
+---
+fix: invoice creation shows a success toast even when it failed

--- a/eval/grill/fixtures/shadow-light-03-sidebar-tooltips.md
+++ b/eval/grill/fixtures/shadow-light-03-sidebar-tooltips.md
@@ -1,0 +1,18 @@
+---
+fixture_id: shadow-light-03-sidebar-tooltips
+mode: diagnosis
+expected_tier: light
+expected_signals: 2
+planted_ambiguities:
+  - root cause unconfirmed — is it a z-index value, or a stacking-context problem?
+  - scope unstated — fix the sidebar only, or the shared tooltip everywhere?
+answer_script:
+  - asks_about: is it a z-index value
+    reply: no — it's a stacking-context trap; the tooltip's z-50 is nested inside a z-10 sidebar ancestor, so it can never rise above the header
+  - asks_about: fix approach
+    reply: wrap the tooltip content in a Portal to document.body so it escapes the sidebar's stacking context; don't change any z-index values
+  - asks_about: scope — sidebar only
+    reply: fix the shared tooltip primitive, so it applies app-wide; the sidebar was just where the symptom showed
+shadow: true
+---
+fix: sidebar tooltips get hidden behind the header when the nav is collapsed

--- a/eval/grill/fixtures/shadow-light-04-auto-assign-ids.md
+++ b/eval/grill/fixtures/shadow-light-04-auto-assign-ids.md
@@ -1,0 +1,22 @@
+---
+fixture_id: shadow-light-04-auto-assign-ids
+mode: spec
+expected_tier: light
+expected_signals: 4
+planted_ambiguities:
+  - ID format unspecified — prefix and zero-padding width?
+  - does this change the existing contractor ID format, or only add building-company IDs?
+  - retroactive scope — existing records renumbered, or new-only?
+  - what if a caller already supplies an ID?
+answer_script:
+  - asks_about: ID format
+    reply: CON-000001 for contractors and BLD-000001 for building companies — a letter prefix, a dash, then 6-digit zero padding
+  - asks_about: existing contractor format
+    reply: yes, the contractor format changes from the old SC0001 to CON-000001 — it's not purely additive
+  - asks_about: retroactive scope
+    reply: new records only; do not renumber or backfill any existing IDs or the sequence counters
+  - asks_about: caller-supplied ID
+    reply: honour it — skip generation entirely when a companyId is already provided on create
+shadow: true
+---
+feat: auto-assign building company IDs and prefix the contractor/company IDs

--- a/eval/grill/fixtures/shadow-light-05-fieldwork-paragraphs.md
+++ b/eval/grill/fixtures/shadow-light-05-fieldwork-paragraphs.md
@@ -1,0 +1,19 @@
+---
+fixture_id: shadow-light-05-fieldwork-paragraphs
+mode: spec
+expected_tier: light
+expected_signals: 3
+planted_ambiguities:
+  - which FieldWork fields get injected, and in what order?
+  - exact insertion point within Key Findings is unstated
+  - fallback when the target heading is absent is undefined
+answer_script:
+  - asks_about: which fields and order
+    reply: siteAccessAndSafety, then initialSiteObservations, then preliminaryFireAssessment — one paragraph each, in that order
+  - asks_about: insertion point
+    reply: at the end of the "Key Findings and Observations" section, just before the next heading
+  - asks_about: heading missing
+    reply: append a new "Key Findings and Observations:" section at the end of the summary; skip any empty source field silently
+shadow: true
+---
+feat: inject the FieldWork paragraphs into the Executive Summary's Key Findings

--- a/eval/grill/fixtures/shadow-skip-01-bold-titles.md
+++ b/eval/grill/fixtures/shadow-skip-01-bold-titles.md
@@ -1,0 +1,10 @@
+---
+fixture_id: shadow-skip-01-bold-titles
+mode: diagnosis
+expected_tier: skip
+expected_signals: 1
+planted_ambiguities: []
+answer_script: []
+shadow: true
+---
+fix: each Fire Cause sub-section in the PDF should render a bold title (e.g. "Area of Fire Origin") with its sentence on the line below, instead of the sentence alone

--- a/eval/grill/fixtures/shadow-skip-02-conclusion-paragraphs.md
+++ b/eval/grill/fixtures/shadow-skip-02-conclusion-paragraphs.md
@@ -1,0 +1,10 @@
+---
+fixture_id: shadow-skip-02-conclusion-paragraphs
+mode: diagnosis
+expected_tier: skip
+expected_signals: 1
+planted_ambiguities: []
+answer_script: []
+shadow: true
+---
+fix: render the PDF Conclusion/Summary section as flowing paragraphs and drop the AI-generated bold subtitles, so it reads as prose instead of a labelled list

--- a/eval/grill/run.sh
+++ b/eval/grill/run.sh
@@ -22,6 +22,10 @@ GATE_CATCH_RATE="0.80"
 
 total_planted=0
 total_surfaced=0
+shadow_planted=0
+shadow_surfaced=0
+nonshadow_planted=0
+nonshadow_surfaced=0
 fail_count=0
 results=""   # accumulated: "fixture_id\ttier\tcoverage\tverdict\n"
 
@@ -67,6 +71,7 @@ for fixture in "$FIXTURES"/*.md; do
   [ -e "$fixture" ] || { echo "ERROR: no fixtures found"; exit 2; }
   fid="$(basename "$fixture" .md)"
   tier="$(sed -n -E 's/^expected_tier:[[:space:]]*//p' "$fixture" | head -1)"
+  shadow="$(sed -n -E 's/^shadow:[[:space:]]*//p' "$fixture" | head -1)"
 
   if ! run_grill "$fixture" > "$WORK/$fid.transcript"; then
     echo "$fid: grill run failed"; fail_count=$((fail_count + 1)); continue
@@ -83,6 +88,11 @@ for fixture in "$FIXTURES"/*.md; do
 
   total_planted=$((total_planted + planted))
   total_surfaced=$((total_surfaced + surfaced))
+  if [ "$shadow" = "true" ]; then
+    shadow_planted=$((shadow_planted + planted));       shadow_surfaced=$((shadow_surfaced + surfaced))
+  else
+    nonshadow_planted=$((nonshadow_planted + planted)); nonshadow_surfaced=$((nonshadow_surfaced + surfaced))
+  fi
   [ "$verdict" = "PASS" ] || fail_count=$((fail_count + 1))
 
   cov="n/a"
@@ -97,11 +107,29 @@ echo
 
 catch_rate="0.00"
 [ "$total_planted" -gt 0 ] && catch_rate="$(awk "BEGIN{printf \"%.2f\", $total_surfaced/$total_planted}")"
-echo "catch-rate: $catch_rate  (gate >= $GATE_CATCH_RATE)"
+shadow_rate="n/a"
+[ "$shadow_planted" -gt 0 ] && shadow_rate="$(awk "BEGIN{printf \"%.2f\", $shadow_surfaced/$shadow_planted}")"
+nonshadow_rate="n/a"
+[ "$nonshadow_planted" -gt 0 ] && nonshadow_rate="$(awk "BEGIN{printf \"%.2f\", $nonshadow_surfaced/$nonshadow_planted}")"
+echo "catch-rate (all):        $catch_rate  (gate >= $GATE_CATCH_RATE)"
+echo "catch-rate (shadow):     $shadow_rate  (the trustworthy number — see README 'shadow subset')"
+echo "catch-rate (non-shadow): $nonshadow_rate"
 echo "fixture failures: $fail_count"
 
 pass="$(awk "BEGIN{print ($catch_rate >= $GATE_CATCH_RATE) ? 1 : 0}")"
-if [ "$pass" -eq 1 ] && [ "$fail_count" -eq 0 ]; then
+
+# Shadow-subset gate. A high all-fixtures rate driven only by non-shadow (author-written)
+# fixtures is not trustworthy: the skill can be tuned to pass fixtures written alongside
+# it. If any shadow fixtures exist, they must ALSO clear the gate. If none exist, the gate
+# is provisional — warn loudly (this is the seed-set state, README "Discipline").
+shadow_pass=1
+if [ "$shadow_planted" -gt 0 ]; then
+  shadow_pass="$(awk "BEGIN{print ($shadow_rate >= $GATE_CATCH_RATE) ? 1 : 0}")"
+else
+  echo "WARNING: no shadow fixtures present — gate is PROVISIONAL (README 'shadow subset')."
+fi
+
+if [ "$pass" -eq 1 ] && [ "$shadow_pass" -eq 1 ] && [ "$fail_count" -eq 0 ]; then
   echo "RESULT: PASS"
 else
   echo "RESULT: FAIL"

--- a/eval/grill/validate-judge.sh
+++ b/eval/grill/validate-judge.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Judge-validation harness for the grill eval judge (see rubric.md "Judge validation").
+# The LLM judge in run.sh must be trusted before its catch-rate is. This script measures
+# judge-vs-human agreement on a fixed 6-fixture subset and gates at >= 75%.
+#
+#   bash eval/grill/validate-judge.sh generate
+#       Runs grill + judge on the subset. Writes transcripts, the judge's own scores,
+#       and a BLANK hand-score sheet you fill in by eye.
+#
+#   # ...open judge-validation/handscore.tsv, read each transcript, fill human_score...
+#
+#   bash eval/grill/validate-judge.sh compare
+#       Reads your filled sheet + the judge scores, computes per-dimension agreement,
+#       prints PASS/FAIL against the 0.75 gate.
+#
+# Dev/QA infra — NOT shipped to target projects. Bash 3.2 compatible (macOS).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FIXTURES="$HERE/fixtures"
+RUBRIC="$HERE/rubric.md"
+SKILL="$HERE/../../skills/espalier-init/templates/skills/espalier-grill.md"
+OUT="$HERE/judge-validation"
+AGREE_GATE="0.75"
+
+# Fixed 6-fixture subset: spans all three tiers and mixes seed + shadow fixtures so the
+# judge is validated across the range it will actually score.
+SUBSET="full-01-dashboard-faster shadow-full-02-decimal-points light-01-csv-export shadow-light-02-invoice-failures skip-01-copyright-year shadow-skip-01-bold-titles"
+
+# Agreement tolerances per dimension (judge vs human counts as agreeing within these):
+#   surfaced        exact count +/- 1
+#   depth_cal       exact (0/1/2)
+#   non_obvious     +/- 0.5
+#   discrimination  +/- 0.5
+
+run_grill() {
+  local fixture="$1"
+  claude -p --output-format text \
+"You are running the espalier-grill skill in EVAL MODE.
+
+EVAL MODE rules: skip Step 0's TTY check — the fixture's answer_script is your
+interactive channel. Use it to answer your own grill questions; never ask a real
+human. Otherwise follow the skill exactly.
+
+Skill definition:
+$(cat "$SKILL")
+
+Fixture (frontmatter holds the answer_script):
+$(cat "$fixture")
+
+Run the grill. Output the full transcript: the tier you chose, every question asked,
+and which answer_script reply you used for each." 2>/dev/null
+}
+
+judge() {
+  local fixture="$1" transcript="$2"
+  claude -p --output-format text \
+"You are the grill eval JUDGE. Rubric:
+$(cat "$RUBRIC")
+
+Fixture:
+$(cat "$fixture")
+
+Grill transcript:
+$(cat "$transcript")
+
+Score the run. Output ONE line of compact JSON only, no prose:
+{\"planted\":N,\"surfaced\":N,\"depth_cal\":0-2,\"non_obvious\":0.0-2.0,\"discrimination\":0.0-2.0,\"verdict\":\"PASS|FAIL\"}" \
+    2>/dev/null
+}
+
+cmd="${1:-}"
+case "$cmd" in
+  generate)
+    [ -f "$SKILL" ] || { echo "ERROR: skill not found at $SKILL"; exit 2; }
+    mkdir -p "$OUT/transcripts"
+    printf 'fixture\tdimension\thuman_score\tnote\n' > "$OUT/handscore.tsv"
+    printf 'fixture\tsurfaced\tdepth_cal\tnon_obvious\tdiscrimination\n' > "$OUT/judge-scores.tsv"
+    for fid in $SUBSET; do
+      fx="$FIXTURES/$fid.md"
+      [ -f "$fx" ] || { echo "ERROR: missing fixture $fid"; exit 2; }
+      echo "grill+judge: $fid"
+      run_grill "$fx" > "$OUT/transcripts/$fid.transcript"
+      line="$(judge "$fx" "$OUT/transcripts/$fid.transcript")"
+      surfaced="$(printf '%s' "$line" | sed -E 's/.*"surfaced":([0-9]+).*/\1/')"
+      depth="$(printf '%s' "$line"    | sed -E 's/.*"depth_cal":([0-9]+).*/\1/')"
+      nonobv="$(printf '%s' "$line"   | sed -E 's/.*"non_obvious":([0-9.]+).*/\1/')"
+      disc="$(printf '%s' "$line"     | sed -E 's/.*"discrimination":([0-9.]+).*/\1/')"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$fid" "$surfaced" "$depth" "$nonobv" "$disc" >> "$OUT/judge-scores.tsv"
+      for dim in surfaced depth_cal non_obvious discrimination; do
+        printf '%s\t%s\t\t\n' "$fid" "$dim" >> "$OUT/handscore.tsv"
+      done
+    done
+    echo
+    echo "Wrote to $OUT :"
+    echo "  transcripts/<fixture>.transcript  — read these to score"
+    echo "  judge-scores.tsv                  — the judge's scores (do not edit)"
+    echo "  handscore.tsv                     — fill the human_score column, then run 'compare'"
+    ;;
+  compare)
+    [ -f "$OUT/handscore.tsv" ]    || { echo "ERROR: no handscore.tsv — run 'generate' first"; exit 2; }
+    [ -f "$OUT/judge-scores.tsv" ] || { echo "ERROR: no judge-scores.tsv — run 'generate' first"; exit 2; }
+    awk -F'\t' '
+      # tolerances
+      function agree(dim, h, j,   d) {
+        if (h == "") return -1                       # unscored cell -> skip
+        d = h - j; if (d < 0) d = -d
+        if (dim == "surfaced")       return (d <= 1) ? 1 : 0
+        if (dim == "depth_cal")      return (h == j) ? 1 : 0
+        if (dim == "non_obvious")    return (d <= 0.5) ? 1 : 0
+        if (dim == "discrimination") return (d <= 0.5) ? 1 : 0
+        return -1
+      }
+      FNR==NR {
+        if (FNR==1) next
+        js[$1] = $0                                  # judge row keyed by fixture
+        surfaced[$1]=$2; depth[$1]=$3; nonobv[$1]=$4; disc[$1]=$5
+        next
+      }
+      FNR==1 { next }                                # skip handscore header
+      {
+        fx=$1; dim=$2; h=$3
+        jv = (dim=="surfaced")?surfaced[fx] : (dim=="depth_cal")?depth[fx] : (dim=="non_obvious")?nonobv[fx] : disc[fx]
+        a = agree(dim, h, jv)
+        if (a < 0) { skipped++; next }
+        total++; if (a==1) agreed++
+        printf "  %-32s %-14s human=%-5s judge=%-5s %s\n", fx, dim, h, jv, (a==1?"agree":"DISAGREE")
+      }
+      END {
+        if (total==0) { print "ERROR: no scored cells in handscore.tsv"; exit 2 }
+        rate = agreed/total
+        printf "\nagreement: %d/%d = %.2f  (gate >= %s)\n", agreed, total, rate, gate
+        if (skipped>0) printf "(%d cells unscored, skipped)\n", skipped
+        if (rate >= gate+0) print "JUDGE: VALIDATED"
+        else { print "JUDGE: NOT VALIDATED — sharpen rubric anchors and re-score"; exit 1 }
+      }
+    ' gate="$AGREE_GATE" "$OUT/judge-scores.tsv" "$OUT/handscore.tsv"
+    ;;
+  *)
+    echo "usage: validate-judge.sh generate|compare"; exit 2 ;;
+esac

--- a/skills/espalier-init/templates/skills/espalier-grill.md
+++ b/skills/espalier-init/templates/skills/espalier-grill.md
@@ -101,8 +101,15 @@ Rules for the loop:
 - **By mode** — `spec`: probe scope (in / out), false premises, edge cases, vague
   terms. `diagnosis`: probe the root cause (symptom vs. cause?), the reproduction,
   and whether the stated "expected behaviour" is actually correct.
+- **Cover every counted signal.** Each ambiguity signal you counted in Step 1 must end
+  either resolved by an answer or consciously ruled out of scope. Stop-early (below)
+  applies only to questions *beyond* the counted signals — never leave a signal you
+  counted unaddressed, because that is exactly the ambiguity grill exists to catch.
+- **Handle a non-answer.** If the user replies "I don't know" / defers, do not silently
+  drop the point: record it under `## Open Questions` in `requirements.md`, pick the
+  safest default, and name that default. An invisible unresolved signal defeats the audit.
 - **Stop early.** Stop the moment the next question's answer would not change the
-  implementation — even before the tier cap.
+  implementation — even before the tier cap (but after every counted signal is covered).
 
 ### Step 3 — Write the resolved input back
 
@@ -116,6 +123,11 @@ batched at the end:
 
 Every grilled decision must land as a verifiable line. Never leave a resolution only
 in the conversation.
+
+**Coverage guard (before returning `GRILLED`).** Re-read the Step 1 signal list. Every
+signal you counted must now appear in `requirements.md` as a resolved criterion, a
+scope-out line, or an `## Open Questions` entry. A counted signal with no written trace
+is a coverage miss — ask it now (within the tier cap) or record it, then return.
 
 ## Verdict
 

--- a/skills/espalier-init/templates/skills/espalier-grill.md
+++ b/skills/espalier-init/templates/skills/espalier-grill.md
@@ -75,7 +75,11 @@ Tier anchors (calibrate against these):
 - `full` — "make the dashboard faster and handle errors better"
 
 State the chosen tier to the user in one line ("Well-specified — confirming, not
-grilling") so a misjudgment is visible and they can correct it.
+grilling") so a misjudgment is visible and they can correct it. If the user pushes
+back on the tier ("this is more involved than that" / "don't bother grilling"), adopt
+their tier and proceed — their read of the requirement's stakes overrides the signal
+count. A `skip`→`light`/`full` bump runs Step 2; a bump down to `skip` returns
+`SKIPPED: crisp`.
 
 ### Step 2 — Grill loop (tiers `light` and `full`)
 


### PR DESCRIPTION
Darwin-skill optimization pass on `espalier-grill` (the Stage 1 interrogation skill emitted to target projects). Two hill-climbing rounds, both kept, validated end-to-end by the golden eval harness.

## Score: 87.0 → 91.2 (+4.2)

| Dimension | Before | After | Δ |
|---|---|---|---|
| 3 Edge coverage | 8 | 9 | +1 |
| 4 Checkpoint | 8 | 9 | +1 |
| 8 Effect (harness) | 9.0 | 10 | +1.0 |

Harness catch-rate: **0.93 → 0.96 → 1.00**, all 9 fixtures perfect coverage, 0 failures.

## Changes to the skill

1. **Coverage guard** — ties Step 1's counted ambiguity signals to Step 3's written resolutions. Closed a real gap: nothing forced grill to address every signal it counted, so a signal could be counted and then silently dropped. Drove full-02 (0.86→1.00) and full-01 (0.83→1.00) — grill now re-checks and asks the previously-missed signal before returning `GRILLED`.
2. **Non-answer fallback** — user "I don't know" / defer now lands under `## Open Questions` with a named safe default, instead of vanishing.
3. **Explicit tier-override** — user pushback on the chosen depth tier now adopts their tier (skip↔light/full). The skill previously claimed "they can correct it" without specifying the mechanism.

File 141 → 152 lines (well under the darwin 150% cap). No behavioral change to well-specified (`skip`) inputs.

## Validation

Each round: edit → commit → real `run.sh` harness (18 headless `claude` calls: grill + LLM judge per fixture) → keep only if total score strictly rose. Both rounds passed the ratchet. Optimization ledger tracked in `eval/grill/auto-optimize-results.tsv`.

## Honest limits (not chased)

- **d8 ceiling is soft.** Seed set is 9 fixtures, all `shadow: false` — authored alongside the skill. `eval/grill/README.md` wants 20–30 fixtures with a ~⅓ shadow subset before the gate is trustworthy. 1.00 here is real but not a shadow-validated number.
- **d1 frontmatter / d6 resource** left alone — phase-loaded skill, cosmetic ROI only.


---

## Follow-on: eliminate the eval's soft-ceiling caveat

The optimization above scored d8=1.00 against a 9-fixture seed set that was all `shadow: false` (written alongside the skill) — a soft number. This half hardens the harness so the number means something.

- **10 shadow fixtures** built from real CNE (`portal.cneaustralia.com.au`) + OCV (`ocv-dashboard`) commit history. The raw commit subject is the ambiguous input; the answer key is derived from what each commit's **diff actually decided** (fields, root cause, scope) — so the key reflects real resolution, not the skill author's intuition. Spans skip/light/full and both spec + diagnosis modes.
- **full-01 key defect fixed** — it planted 6 ambiguities but scripted only 5 answers (6/6 now).
- **`run.sh` shadow gate** — reports all / shadow / non-shadow catch-rate. The shadow subset must independently clear the 0.80 gate; a high all-rate carried only by author-written fixtures no longer passes. Warns PROVISIONAL when no shadow fixtures exist.
- **`validate-judge.sh`** — judge-vs-human agreement harness (`rubric.md` "Judge validation"), gates at ≥0.75. The catch-rate is only as trustworthy as the judge; this confirms it before the number is trusted.

**Full 19-fixture run: all PASS, shadow catch-rate 1.00, non-shadow 1.00.**

### Residual (honest)
- **Judge not yet validated.** 1.00 depends on the LLM judge not being lenient. `validate-judge.sh` exists but needs a human to hand-score the 6-subset (~15 min) and clear ≥75%. Until then, treat 1.00 as "very likely real," not proven.
- **19 fixtures** — one shy of the plan's 20 floor; add a handful more to close it.
