### PR TITLE
v0.9.5 — migration-chain repair

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Zayhan"
   },
   "description": "Marketplace publishing the Espalier Engineering plugin — auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.9.3",
+  "version": "0.9.5",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -13,7 +13,7 @@
         "repo": "Junhanliu-dev/espalier-engineering"
       },
       "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.9.3",
+      "version": "0.9.5",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
   "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.9.3",
+  "version": "0.9.5",
   "author": {
     "name": "Zayhan"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 0.9.5 — 2026-07-09
+
+Patch: **migration-chain repair** — two bugs made the documented upgrade path fail for
+installs that reached v0.9.x by migrating rather than by a fresh `/espalier-init`. No
+new lane, stage, gate, or verdict behaviour; no change to what a fresh init produces.
+
+**`/espalier-migrate` could not reach v0.9.3.**
+
+- `scripts/migrate-v0.9.2-to-v0.9.3.sh` shipped in 0.9.3, but `skills/espalier-migrate/SKILL.md`
+  never referenced it — no `NEEDS_` flag, no detection, no dry-run line, no apply line.
+  Followed literally, the skill stopped at v0.9.2 and reported "Already fully up to date",
+  leaving the v0.9.3 grill + review changes unreachable for every install.
+- Adds `NEEDS_V093_PATCH`, detecting on the same two markers the script uses for its own
+  idempotency check (grill `Coverage guard (before returning`, review
+  `SINGLE SOURCE for these checks`), plus the dry-run, apply, chain prose, and flags entry.
+
+**`migrate-v0.8.2-to-v0.9.0.sh` never wrote to the review skill.**
+
+- It declared `REVIEWSKILL="espalier/skills/espalier-review/SKILL.md"` and never referenced
+  the variable again, so the `espalier-review` SKILL never received its
+  `## Production-Readiness Checks` section. Fresh v0.9.0+ inits get the section from
+  `templates/skills/espalier-review.md`; migrated installs did not — and
+  `migrate-v0.9.2-to-v0.9.3.sh` requires it, dying with
+  `ERROR: install missing section '## Production-Readiness Checks'`.
+- The section is now appended via the existing `append_section` helper, guarded on the bare
+  heading so both the v0.9.0 form (with the rules-path suffix) and the v0.9.3 form count as
+  already-present.
+- The section text is **inlined rather than extracted from the template**. On a v0.9.3+
+  plugin the template section carries the phrase `SINGLE SOURCE for these checks`, which is
+  exactly the marker `migrate-v0.9.2-to-v0.9.3.sh` greps to decide the review skill is
+  already patched. Extracting it would have made v0.9.3 report "already at v0.9.3 — nothing
+  to do" and silently skip its own frontmatter + Two-Review-Loops splice — a passing no-op.
+- The section joins the already-v0.9.0 detector (ten artifacts → eleven) and the verification
+  block, so an install migrated by an earlier build is completed on re-run rather than
+  short-circuiting. The `/espalier-migrate` v0.9.0 detection flags a missing section too, so
+  the chain self-repairs before v0.9.3 needs it.
+
+**Also:**
+
+- The plugin-locate probe in `espalier-migrate` now looks for the newest migration script
+  (`migrate-v0.9.2-to-v0.9.3.sh`) instead of `migrate-v0.7-to-v0.8.sh`. A plugin predating the
+  current chain now fails to resolve with a clear "update the plugin" message rather than
+  resolving and dying mid-apply on a missing script.
+- Documents that a dry-run preview of a later step may legitimately refuse until its
+  prerequisite step has been applied (e.g. the v0.9.2 preview needs the `pipeline.md` that
+  v0.9.1 rewrites) — the refusal is a precondition guard, not a failure.
+- Notes that the v0.9.2 gate check `^TEST_OUTPUT=` assumes the single-host-command shape
+  `hook-templates/pre-push-gate.sh` generates; a gate customised at init to run tests another
+  way (e.g. per-container `docker compose exec`) cannot satisfy it, warns, and reports that one
+  check as `✗`. Template-shape mismatch, not a failed migration.
+- **Version fields corrected.** `plugin.json` and `marketplace.json` still declared `0.9.3`
+  after the v0.9.4 release, which bumped only `CHANGELOG.md`. All three fields now read `0.9.5`.
+
+Validated against a synthetic v0.9.2 install: the original `install missing section` error
+reproduced, then cleared, with the project-substituted checklist lines preserved and no literal
+`{project}` leaked; re-run is a clean no-op. `scripts/test-bootstrap.sh` 60/60.
+
 ## 0.9.4 — 2026-07-08
 
 Patch: **security eval expansion + skill clarity** — dev/QA infra plus sharper skill

--- a/scripts/migrate-v0.8.2-to-v0.9.0.sh
+++ b/scripts/migrate-v0.8.2-to-v0.9.0.sh
@@ -129,7 +129,7 @@ if ! grep -qF "fixpoint loop" espalier/pipeline.md 2>/dev/null; then
   exit 1
 fi
 
-# Already-v0.9.0 detector — ALL TEN artifacts must be present (security + audit + production), not just the two
+# Already-v0.9.0 detector — ALL ELEVEN artifacts must be present (security + audit + production), not just the two
 # that Step 3 (bootstrap) produces. Checking only panel+agent would report "done"
 # after a crash between Step 3 and Step 4, leaving the coder/reviewer/testing
 # appends and the gate scan missing — a silently incomplete install that a re-run
@@ -152,10 +152,17 @@ PROD_DONE=no; PRODCODER_DONE=no; GATECD_DONE=no
 [ -f "$PRODRULE" ] && PROD_DONE=yes
 grep -qF "## Production-Aware Coding" "$CODER" 2>/dev/null && PRODCODER_DONE=yes
 grep -qF "cd defensively too" "$GATE" 2>/dev/null && GATECD_DONE=yes
+# The review SKILL's production checklist. Included so an install migrated by an
+# earlier build of THIS script — which declared $REVIEWSKILL but never wrote to it
+# — is completed on re-run, instead of short-circuiting here and then failing
+# migrate-v0.9.2-to-v0.9.3.sh with "install missing section".
+REVIEWCHECKS_DONE=no
+grep -qF "## Production-Readiness Checks" "$REVIEWSKILL" 2>/dev/null && REVIEWCHECKS_DONE=yes
 if [ "$PANEL_DONE" = yes ] && [ "$AGENT_DONE" = yes ] && [ "$CODER_DONE" = yes ] \
    && [ "$REVIEWER_DONE" = yes ] && [ "$GATE_DONE" = yes ] \
    && [ "$AUDIT_DONE" = yes ] && [ "$MODE_DONE" = yes ] \
-   && [ "$PROD_DONE" = yes ] && [ "$PRODCODER_DONE" = yes ] && [ "$GATECD_DONE" = yes ]; then
+   && [ "$PROD_DONE" = yes ] && [ "$PRODCODER_DONE" = yes ] && [ "$GATECD_DONE" = yes ] \
+   && [ "$REVIEWCHECKS_DONE" = yes ]; then
   echo "Already on v0.9.0 (all security + production artifacts present)."
   echo "Nothing to do."
   exit 0
@@ -315,6 +322,32 @@ emit_prod_testing_section() {
     "## Failure-Mode Tests (every NEW external-call path)" "## What NOT to Test"
 }
 
+# The espalier-review SKILL gains the production checklist too. Fresh v0.9.0+
+# inits get it from templates/skills/espalier-review.md; a MIGRATED install never
+# did, which later makes migrate-v0.9.2-to-v0.9.3.sh die with
+# "install missing section '## Production-Readiness Checks'".
+#
+# Deliberately inlined rather than _extract_section'd from the template: on a
+# v0.9.3+ plugin the template section carries the phrase "SINGLE SOURCE for these
+# checks", which is exactly the marker migrate-v0.9.2-to-v0.9.3.sh greps to decide
+# the review skill is ALREADY patched. Extracting it here would make v0.9.3 skip
+# its own Two-Review-Loops + frontmatter splice. Emit the v0.9.0-era text instead
+# and let v0.9.3 replace it, as it does for a fresh v0.9.0 install.
+emit_prod_review_checks_section() {
+cat << 'EOF'
+
+## Production-Readiness Checks (espalier/rules/production-standards.md)
+Severity tiers are defined in the rule — P0 for the data-loss class, P1 for
+production-readiness gaps.
+- [ ] External calls carry a timeout + decided failure behaviour (P1 if not)
+- [ ] List queries on request paths are bounded/paginated (P1); no N+1 on hot paths
+- [ ] New endpoints/consumers emit a structured log — actor, entity id, outcome (P1)
+- [ ] No swallowed errors; persistence-path failures never continue as success (P0 on money/state paths)
+- [ ] Migrations follow expand → migrate → contract; destructive steps are requirement-authorized (P0 if not)
+- [ ] Mutating consumers/webhooks are idempotent under redelivery (P1)
+EOF
+}
+
 # The VERDICT sentinel + overwrite-per-round contract lives inline in the fresh
 # template's Output Format, which bootstrap --force does NOT re-copy to a
 # per-project agent. Append it to a migrated agent so the refreshed orchestrator
@@ -468,6 +501,11 @@ append_section "$TESTING"  "## Security Abuse Tests"           emit_testing_sect
 append_section "$CODER"    "## Production-Aware Coding"        emit_prod_coder_section
 append_section "$REVIEWER" "## Production-Readiness Review"    emit_prod_reviewer_section
 append_section "$TESTING"  "## Failure-Mode Tests"            emit_prod_testing_section
+# The review SKILL (not the reviewer AGENT). Fresh inits carry this from the
+# template; migrated installs did not, and v0.9.3's surgical patch requires it.
+# The marker is the bare heading, so both the v0.9.0 form (with the
+# "(espalier/rules/...)" suffix) and the v0.9.3 form count as already-present.
+append_section "$REVIEWSKILL" "## Production-Readiness Checks" emit_prod_review_checks_section
 # VERDICT sentinel contract — per-project agents predate it; the refreshed
 # orchestrator greps `^VERDICT:`. Guard on the sentinel token so a fresh install
 # (carries it inline in Output Format) is a no-op.
@@ -611,6 +649,7 @@ else
   check "scout-prompts shipped"                         "test -f espalier/.scout-prompts.md"
   check "coder has Production-Aware Coding"             "grep -qF '## Production-Aware Coding' $CODER"
   check "reviewer has Production-Readiness Review"      "grep -qF '## Production-Readiness Review' $REVIEWER"
+  check "review skill has Production-Readiness Checks"  "grep -qF '## Production-Readiness Checks' $REVIEWSKILL"
   check "testing skill has failure-mode tests"         "grep -qF '## Failure-Mode Tests' $TESTING"
   check "push gate has cwd fail-closed guard"          "grep -qF 'cd defensively too' $GATE"
   check "pipeline Stage 9 is deploy-aware"             "grep -qF 'no-deploy-config' espalier/pipeline.md"

--- a/skills/espalier-migrate/SKILL.md
+++ b/skills/espalier-migrate/SKILL.md
@@ -94,15 +94,33 @@ version. Up to TWELVE migrations may apply, always in this order:
    test command; scout 1.11 ships in `.scout-prompts.md` and prune/doctor map
    the security/production rules. Backs up customised pure-copy files to
    `<file>.pre-v0.9.2.bak`. Mechanical: `scripts/migrate-v0.9.1-to-v0.9.2.sh`.
+13. **v0.9.2 → v0.9.3** — skill-clarity patch; no new lane, no new stage, no
+   behaviour change to any gate or verdict. `espalier-grill` (pure-copy) gains an
+   explicit user tier-override, a coverage guard so every counted ambiguity signal
+   ends resolved / scoped-out / recorded in `## Open Questions`, and records a
+   non-answer with a named safe default instead of dropping it. `espalier-review`
+   (substituted) gets its two review loops rewritten as an explicit
+   when / input / do / output / who workflow, stops restating severities in the
+   production-readiness checklist (`production-standards.md` is the single source),
+   and gains when-to-use + trigger phrases in its frontmatter. Backs both skills up
+   to `<file>.pre-v0.9.3.bak`. Mechanical: `scripts/migrate-v0.9.2-to-v0.9.3.sh`.
 
 Your job: detect which one(s) apply, locate the scripts, preview, get
-confirmation, apply in order. A v0.1.x install needs ALL TWELVE; a v0.3.x
-install needs the last eleven; a v0.4.x install needs the last ten; a
-v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.9.2; a v0.5.3–v0.5.x
-install needs v0.6 … v0.9.2; a v0.6.x install needs v0.7 … v0.9.2; a v0.7.x
-install needs v0.8 … v0.9.2; a v0.8.0 install needs v0.8.1 … v0.9.2; a v0.8.1
-install needs v0.8.2 … v0.9.2; a v0.8.2 install needs v0.9.0 … v0.9.2; a
-v0.9.0 install needs v0.9.1 then v0.9.2; a v0.9.1 install needs only v0.9.2.
+confirmation, apply in order. A v0.1.x install needs ALL THIRTEEN; a v0.3.x
+install needs the last twelve; a v0.4.x install needs the last eleven; a
+v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.9.3; a v0.5.3–v0.5.x
+install needs v0.6 … v0.9.3; a v0.6.x install needs v0.7 … v0.9.3; a v0.7.x
+install needs v0.8 … v0.9.3; a v0.8.0 install needs v0.8.1 … v0.9.3; a v0.8.1
+install needs v0.8.2 … v0.9.3; a v0.8.2 install needs v0.9.0 … v0.9.3; a
+v0.9.0 install needs v0.9.1 … v0.9.3; a v0.9.1 install needs v0.9.2 then v0.9.3;
+a v0.9.2 install needs only v0.9.3.
+
+Note: `migrate-v0.9.2-to-v0.9.3.sh` requires the installed `espalier-review`
+SKILL to carry a `## Production-Readiness Checks` section. Fresh v0.9.0+ inits
+have it from the template, and `migrate-v0.8.2-to-v0.9.0.sh` now appends it to
+migrated installs. An install migrated by an older build of that script lacks the
+section — re-running the v0.9.0 step (idempotent) adds it, which is why the chain
+below never skips ahead.
 
 ### Step 1: Preflight + detect install version
 
@@ -121,6 +139,7 @@ NEEDS_V082_PATCH=no
 NEEDS_V09_MINOR=no
 NEEDS_V091_PATCH=no
 NEEDS_V092_PATCH=no
+NEEDS_V093_PATCH=no
 
 if [ ! -d "harness" ] && [ ! -d "espalier" ]; then
   echo "ERROR: no harness/ or espalier/ dir found — not a target install."
@@ -144,6 +163,7 @@ if [ -d "harness" ]; then
   NEEDS_V09_MINOR=yes        # ...then the v0.9.0 security audit
   NEEDS_V091_PATCH=yes       # ...then the v0.9.1 configurable escalation caps
   NEEDS_V092_PATCH=yes       # ...then the v0.9.2 correctness patch
+  NEEDS_V093_PATCH=yes       # ...then the v0.9.3 skill-clarity patch
 elif [ -d "espalier" ]; then
   # Already renamed. v0.4.x still needs the doc-drift upgrade.
   if [ ! -f "espalier/hooks/drift-detect.sh" ] || [ ! -f "espalier/.doctor-cadence" ]; then
@@ -195,12 +215,19 @@ elif [ -d "espalier" ]; then
   # pipeline; harness-security.md is a new per-project file a plugin update
   # cannot reach — any absent ⇒ pre-v0.9.0 (or a pre-fold v0.9.0 the script
   # completes idempotently).
+  #
+  # The espalier-review SKILL's "## Production-Readiness Checks" is in this set on
+  # purpose. An install migrated by an older build of migrate-v0.8.2-to-v0.9.0.sh
+  # never received it (that script declared the path but never wrote to it), and
+  # migrate-v0.9.2-to-v0.9.3.sh dies without it. Flagging it here re-runs the
+  # (idempotent) v0.9.0 step, which appends the section before v0.9.3 needs it.
   if ! grep -qF "review panel" espalier/pipeline.md 2>/dev/null \
      || [ ! -f espalier/agents/harness-security.md ] \
      || [ ! -f espalier/skills/espalier-audit/SKILL.md ] \
      || ! grep -qF "## Repo-Audit Mode" espalier/agents/harness-security.md 2>/dev/null \
      || [ ! -f espalier/rules/production-standards.md ] \
      || ! grep -qF "## Production-Aware Coding" espalier/agents/harness-coder.md 2>/dev/null \
+     || ! grep -qF "## Production-Readiness Checks" espalier/skills/espalier-review/SKILL.md 2>/dev/null \
      || ! grep -qF "cd defensively too" espalier/hooks/pre-push-gate.sh 2>/dev/null; then
     NEEDS_V09_MINOR=yes
   fi
@@ -221,6 +248,15 @@ elif [ -d "espalier" ]; then
      || ! grep -qF "Scout 1.11" espalier/.scout-prompts.md 2>/dev/null; then
     NEEDS_V092_PATCH=yes
   fi
+  # v0.9.3: skill-clarity patch. Same two markers migrate-v0.9.2-to-v0.9.3.sh uses
+  # for its own idempotency check — keep them in sync with that script:
+  #   grill  → "Coverage guard (before returning"
+  #   review → "SINGLE SOURCE for these checks"
+  # Either missing ⇒ pre-v0.9.3 (or a half-applied run the script finishes).
+  if ! grep -qF "Coverage guard (before returning" espalier/skills/espalier-grill/SKILL.md 2>/dev/null \
+     || ! grep -qF "SINGLE SOURCE for these checks" espalier/skills/espalier-review/SKILL.md 2>/dev/null; then
+    NEEDS_V093_PATCH=yes
+  fi
 fi
 
 if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
@@ -228,7 +264,8 @@ if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
    && [ "$NEEDS_V05_V06" = no ] && [ "$NEEDS_V06_V07" = no ] \
    && [ "$NEEDS_V07_V08" = no ] && [ "$NEEDS_V08_PATCH" = no ] \
    && [ "$NEEDS_V082_PATCH" = no ] && [ "$NEEDS_V09_MINOR" = no ] \
-   && [ "$NEEDS_V091_PATCH" = no ] && [ "$NEEDS_V092_PATCH" = no ]; then
+   && [ "$NEEDS_V091_PATCH" = no ] && [ "$NEEDS_V092_PATCH" = no ] \
+   && [ "$NEEDS_V093_PATCH" = no ]; then
   echo "Already fully up to date. Nothing to do."
   exit 0
 fi
@@ -249,7 +286,7 @@ never a stray `$HOME` checkout that merely shares the name.
 PLUGIN_DIR=""
 # Primary: derive the plugin root from the skill's own location.
 if [ -n "${CLAUDE_SKILL_DIR:-}" ] \
-   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.7-to-v0.8.sh" ]; then
+   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.9.2-to-v0.9.3.sh" ]; then
   PLUGIN_DIR="$(cd "${CLAUDE_SKILL_DIR}/../.." && pwd)"
 fi
 
@@ -258,7 +295,7 @@ fi
 if [ -z "$PLUGIN_DIR" ]; then
   for candidate in "${ESPALIER_PLUGIN_DIR:-}" "$HOME/repos/espalier-engineering"; do
     [ -n "$candidate" ] || continue
-    if [ -f "$candidate/scripts/migrate-v0.7-to-v0.8.sh" ]; then
+    if [ -f "$candidate/scripts/migrate-v0.9.2-to-v0.9.3.sh" ]; then
       PLUGIN_DIR="$candidate"
       break
     fi
@@ -273,9 +310,12 @@ if [ -z "$PLUGIN_DIR" ]; then
 fi
 ```
 
-If the primary path misses and the fallback fires, the plugin install is
-likely stale (no `migrate-v0.7-to-v0.8.sh`) — tell the user to
-`/plugin update espalier-engineering` first.
+The probe is the NEWEST migration script, so a plugin that predates the current
+chain fails to resolve rather than resolving and then dying on a missing script
+mid-apply. If the primary path misses and the fallback fires, the plugin install
+is likely stale (no `migrate-v0.9.2-to-v0.9.3.sh`) — tell the user to
+`/plugin update espalier-engineering` first. Bump this probe whenever a new
+migration script is added.
 
 ### Step 3: Show dry-run preview for each applicable migration
 
@@ -295,7 +335,14 @@ verbatim:
 [ "$NEEDS_V09_MINOR" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.8.2-to-v0.9.0.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V091_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.0-to-v0.9.1.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V092_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.1-to-v0.9.2.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
+[ "$NEEDS_V093_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.2-to-v0.9.3.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 ```
+
+A dry-run for a step whose prerequisite has not been applied yet may refuse with
+an error (e.g. the v0.9.2 preview needs a `pipeline.md` that the v0.9.1 step
+rewrites). That is expected in a multi-step chain — the refusal is the script
+guarding its own precondition, not a failure. Surface it and continue; Step 6
+applies the steps in order, so the prerequisite is satisfied by then.
 
 ### Step 4: If v0.4→v0.5 applies, pick the doctor cadence
 
@@ -346,6 +393,7 @@ completed.
 [ "$NEEDS_V09_MINOR" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.8.2-to-v0.9.0.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V091_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.0-to-v0.9.1.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V092_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.1-to-v0.9.2.sh" --yes --plugin-dir="$PLUGIN_DIR"
+[ "$NEEDS_V093_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.2-to-v0.9.3.sh" --yes --plugin-dir="$PLUGIN_DIR"
 ```
 
 Each script's verification block prints `X passed, Y failed`. Surface every
@@ -509,12 +557,19 @@ tools-mode substitution, then `bootstrap --force` refreshes the pure-copy
 pipeline/grill files + drift-helpers/wrapper/lookup hooks + copies scout-prompts
 + symlinks both new rules + the audit skill + runs the 37-check validation.
 Surgically appends the security AND production sections to the per-project
-`harness-coder.md` / `harness-reviewer.md` / `espalier-testing` SKILL (and the
-Repo-Audit Mode section to a pre-fold `harness-security.md`), inserts the
-secret/dependency scan + the cwd fail-closed guard into `pre-push-gate.sh`, and
-patches CLAUDE.md + `espalier/agent.md`. Idempotent — the already-v0.9.0 check
-requires all ten artifacts present (security + audit + production), so a crash
-mid-run is completed on re-run.
+`harness-coder.md` / `harness-reviewer.md` / `espalier-testing` SKILL /
+`espalier-review` SKILL (and the Repo-Audit Mode section to a pre-fold
+`harness-security.md`), inserts the secret/dependency scan + the cwd fail-closed
+guard into `pre-push-gate.sh`, and patches CLAUDE.md + `espalier/agent.md`.
+Idempotent — the already-v0.9.0 check requires all eleven artifacts present
+(security + audit + production), so a crash mid-run is completed on re-run.
+
+The `espalier-review` SKILL's `## Production-Readiness Checks` section is part of
+that set. Fresh v0.9.0+ inits get it from the template; earlier builds of this
+script declared the path but never wrote to it, so installs migrated by them lack
+the section and `migrate-v0.9.2-to-v0.9.3.sh` refuses to patch them. Because the
+section is in the already-v0.9.0 check, re-running this step on such an install
+adds it rather than reporting "Nothing to do".
 
 **v0.9.0→v0.9.1 (`migrate-v0.9.0-to-v0.9.1.sh`):**
 
@@ -546,6 +601,35 @@ hook templates, and two anchored surgical patches update the per-project
 substituted test command is read out of the old gate and carried forward).
 Warn + manual snippet if the gate was customised past the anchors. Idempotent —
 re-running detects an already-v0.9.2 install and no-ops.
+
+The `^TEST_OUTPUT=` check assumes the gate runs ONE test command on the host, the
+shape `hook-templates/pre-push-gate.sh` generates. A project whose gate was
+customised at init to run tests another way (e.g. per-container `docker compose
+exec`) cannot satisfy it: the surgical patch warns and prints a manual snippet,
+and that one check reports `✗`. That is a template-shape mismatch, not a failed
+migration — the guard it really enforces is that no `{test_command}` placeholder
+was left unsubstituted.
+
+**v0.9.2→v0.9.3 (`migrate-v0.9.2-to-v0.9.3.sh`):**
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Show actions only |
+| `--yes` | Skip the apply confirmation prompt |
+| `--plugin-dir=<path>` | Path to the espalier-engineering plugin checkout |
+
+Backs up `espalier-grill` + `espalier-review` (`<file>.pre-v0.9.3.bak`), refreshes
+the pure-copy `espalier-grill` SKILL from the template, then re-splices the three
+changed sections of the substituted `espalier-review` SKILL (frontmatter
+description, `## Two Review Loops`, `## Production-Readiness Checks`), preserving
+every init-substituted section — notably the `{detected convention}` checklist
+line. Requires `python3`. Idempotent — re-running detects both v0.9.3 markers and
+no-ops.
+
+Fails closed with `ERROR: install missing section` if the installed
+`espalier-review` lacks `## Production-Readiness Checks`. That means the v0.9.0
+step never ran (or ran from a build predating its review-skill patch) — re-run the
+v0.9.0 step, which is idempotent and adds the section.
 
 ## Anti-Patterns
 


### PR DESCRIPTION
Two bugs made the documented upgrade path fail for installs that reached v0.9.x by **migrating** rather than by a fresh `/espalier-init`. Neither affects a fresh init. PATCH per CONTRIBUTING: bug fix, no surface change.

## 1. `/espalier-migrate` could not reach v0.9.3

`scripts/migrate-v0.9.2-to-v0.9.3.sh` shipped in 0.9.3, but `skills/espalier-migrate/SKILL.md` never referenced it — no `NEEDS_` flag, no detection, no dry-run line, no apply line. Followed literally, the skill stopped at v0.9.2 and reported *"Already fully up to date"*, leaving the v0.9.3 grill + review changes unreachable for every install.

## 2. `migrate-v0.8.2-to-v0.9.0.sh` never wrote to the review skill

It declared `REVIEWSKILL="espalier/skills/espalier-review/SKILL.md"` on line 77 and never referenced the variable again. So the `espalier-review` SKILL never received `## Production-Readiness Checks`. Fresh v0.9.0+ inits get it from the template; migrated installs did not — and `migrate-v0.9.2-to-v0.9.3.sh` **requires** it:

```
ERROR: install missing section '## Production-Readiness Checks' (unexpected v0.9.2 layout)
```

Confirmed no migrate script anywhere creates that heading; the v0.9.3 script only ever re-splices it.

### Why the section text is inlined, not `_extract_section`'d

On a v0.9.3+ plugin the template section carries the phrase `SINGLE SOURCE for these checks` — which is exactly the marker `migrate-v0.9.2-to-v0.9.3.sh` greps to decide the review skill is *already patched*. Extracting it would make v0.9.3 print `already at v0.9.3 — nothing to do`, exit 0, and silently skip its own frontmatter + Two-Review-Loops splice.

I verified this counterfactually: appending the template's section produced a passing no-op with stale frontmatter and stale loops. The inlined v0.9.0-era text is load-bearing.

## Also

- Plugin-locate probe now targets the newest migration script, so a stale plugin fails to resolve with "update the plugin" instead of dying mid-apply.
- Documents that a later step's dry-run may legitimately refuse until its prerequisite is applied.
- Notes that the v0.9.2 `^TEST_OUTPUT=` gate check assumes the single-host-command template shape; a gate customised to run tests per-container cannot satisfy it (warns; that one check reports `✗`).
- **Version fields corrected** — `plugin.json` / `marketplace.json` still said `0.9.3` after the v0.9.4 release, which bumped only `CHANGELOG.md`. All three now read `0.9.5`.

## Verification

- Reproduced `install missing section` on a synthetic v0.9.2 install, applied the fix, got `description + 2 sections re-spliced` — project-substituted checklist lines preserved, no literal `{project}` leaked, re-run a clean no-op.
- Detector checked across three states: broken migrated install → flags v0.9.0 re-run + v0.9.3; fully-v0.9.3 install → all clear; section stripped → flags again.
- `scripts/test-bootstrap.sh` — 60/60.
- All four bash blocks in `SKILL.md` pass `bash -n`.