### PR TITLE
v0.9.6 — the v0.9.4 migration that was never written

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Zayhan"
   },
   "description": "Marketplace publishing the Espalier Engineering plugin — auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -13,7 +13,7 @@
         "repo": "Junhanliu-dev/espalier-engineering"
       },
       "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
   "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "author": {
     "name": "Zayhan"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.9.6 — 2026-07-09
+
+Patch: **the v0.9.4 migration that was never written**, plus a stale skill description
+shipped in 0.9.5. Same bug class as 0.9.5: an improvement lands in the init templates,
+and nothing carries it to installs that already exist.
+
+**New: `scripts/migrate-v0.9.3-to-v0.9.4.sh`.**
+
+v0.9.4 sharpened two **per-project** files — the `harness-security` agent and the
+`espalier-security` skill — but shipped no migration script. Both are created at init
+(or by `migrate-v0.8.2-to-v0.9.0.sh`) with `{project}` substituted, so `bootstrap --force`
+never re-copies them and a plugin update cannot reach them. No existing install ever
+received those improvements.
+
+The new script surgically re-splices exactly the changed regions:
+
+- the `description:` frontmatter line of each file, taken from the v0.9.4 template, with
+  this project's name substituted into the skill's;
+- the agent's `## Priority Rubric` P0 bullet and its Repo-Audit Mode "findings do not
+  block" delta, which now cross-reference one source instead of restating each other.
+
+Two things it deliberately does **not** do:
+
+- **It never rewrites frontmatter wholesale.** An install created in `inherit` tools-mode
+  has had its `tools:` line stripped; copying the template's frontmatter would silently
+  reintroduce it. Only the `description:` line is replaced, and verification asserts the
+  install's original tools-mode survived.
+- **A customised body span is left alone and reported warn-only**, not `✗`. The v0.9.4
+  wording is a clarity improvement, not a behaviour change, so a project that rewrote a
+  span keeps its version and the script still exits 0 after applying every span it could
+  match. (A hard failure there would tell the user to restore from backup after a skip the
+  script chose on purpose.)
+
+Verified against a real migrated install: the patched agent is **byte-identical to what a
+fresh v0.9.4 init produces**, once `{project_name}` is substituted and `tools:` stripped
+for inherit mode. Idempotent; re-running detects both v0.9.4 markers and no-ops.
+
+**Fixed: `espalier-migrate`'s frontmatter description was stale.**
+
+0.9.5 wired the v0.9.3 step into the skill's *body* — detection, dry-run, apply, prose,
+flags — but left the `description:` line enumerating migrations only through "the v0.9.2
+correctness patch". That line is what Claude reads to decide whether to invoke the skill.
+It now lists v0.9.3 and v0.9.4, and "Up to TWELVE migrations" reads FOURTEEN.
+
+**Also:**
+
+- `NEEDS_V094_PATCH` joins the chain, detecting on the same two markers the new script uses
+  for its own idempotency check (agent `self-noops on changes with no sensitive surface`,
+  skill `abuse-test recipe for`). An install with neither security file yet is flagged too —
+  the v0.9.0 step creates them, then v0.9.4 sharpens them.
+- The plugin-locate probe moves to the newest migration script (`migrate-v0.9.3-to-v0.9.4.sh`),
+  so a plugin predating the current chain fails to resolve with "update the plugin" rather
+  than dying mid-apply.
+
+`scripts/test-bootstrap.sh` 60/60. All four bash blocks in `SKILL.md` pass `bash -n`.
+
 ## 0.9.5 — 2026-07-09
 
 Patch: **migration-chain repair** — two bugs made the documented upgrade path fail for

--- a/scripts/migrate-v0.9.3-to-v0.9.4.sh
+++ b/scripts/migrate-v0.9.3-to-v0.9.4.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# Migrate an Espalier v0.9.3 target repo to v0.9.4.
+#
+# Run from the TARGET project root. Idempotent. Safe to re-run.
+# Use --dry-run to preview before applying.
+#
+# v0.9.4 is a security-skill clarity patch — no new lane, no new stage, no
+# behaviour change to any gate or verdict. The security auditor's catch /
+# false-positive behaviour is unchanged (eval 1.00 / 0 before and after):
+#   - harness-security (per-project AGENT): frontmatter description gains
+#     when-to-use + the five sensitive axes as trigger context; the P0 rubric and
+#     the repo-audit "findings do not block" delta stop restating each other's
+#     semantics and cross-reference one source instead.
+#   - espalier-security (per-project SKILL): frontmatter description gains
+#     when-to-use + trigger context.
+#
+# Both are per-project files created by init (or by migrate-v0.8.2-to-v0.9.0.sh)
+# with {project} substituted, so a plugin update never reaches them and
+# `bootstrap --force` does not re-copy them. v0.9.4 shipped these template
+# improvements with no migration script, so no existing install ever received
+# them. This script surgically re-splices exactly the changed regions.
+#
+# This migration:
+#   1. Backs up harness-security.md + espalier-security SKILL.md → <file>.pre-v0.9.4.bak
+#   2. Replaces the `description:` frontmatter line of each from the v0.9.4
+#      template (substituting this project's name into the skill's).
+#   3. Replaces the two changed body spans of harness-security.md.
+#   4. Verifies everything landed.
+#
+# The frontmatter is edited LINE-WISE, never rewritten: an install created in
+# `inherit` tools-mode has had its `tools:` line stripped, and re-copying the
+# template's frontmatter would silently reintroduce it.
+#
+# Usage: bash migrate-v0.9.3-to-v0.9.4.sh [--dry-run] [--yes] [--plugin-dir=<path>]
+
+set -u
+
+DRY_RUN=no
+SKIP_PROMPT=no
+PLUGIN_DIR="${ESPALIER_PLUGIN_DIR:-${HARNESS_PLUGIN_DIR:-}}"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)      DRY_RUN=yes ;;
+    --yes)          SKIP_PROMPT=yes ;;
+    --plugin-dir=*) PLUGIN_DIR="${arg#--plugin-dir=}" ;;
+    -h|--help)      sed -n '2,38p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown flag: $arg (use --help)" >&2; exit 2 ;;
+  esac
+done
+
+log() { echo "[migrate-v0.9.4] $*"; }
+die() { echo "[migrate-v0.9.4] ERROR: $*" >&2; exit 1; }
+
+SECAGENT="espalier/agents/harness-security.md"
+SECSKILL="espalier/skills/espalier-security/SKILL.md"
+
+# --- Locate the installed espalier tree + the v0.9.4 plugin templates --------
+[ -f "$SECAGENT" ] || die "run me from the TARGET project root ($SECAGENT not found).
+If this install predates v0.9.0, run the v0.9.0 step first — it creates the agent."
+[ -f "$SECSKILL" ] || die "$SECSKILL not found — run the v0.9.0 step first."
+
+if [ -z "$PLUGIN_DIR" ]; then
+  for c in \
+    "$HOME/.claude/plugins/espalier-engineering" \
+    "$HOME/.claude/plugins/marketplaces/espalier-engineering/espalier-engineering" \
+    "$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)"; do
+    [ -f "$c/skills/espalier-init/templates/agents/harness-security.md" ] && PLUGIN_DIR="$c" && break
+  done
+fi
+[ -n "$PLUGIN_DIR" ] || die "cannot locate the plugin; pass --plugin-dir=<path to plugin root>."
+
+TPL_AGENT="$PLUGIN_DIR/skills/espalier-init/templates/agents/harness-security.md"
+TPL_SKILL="$PLUGIN_DIR/skills/espalier-init/templates/skills/espalier-security.md"
+[ -f "$TPL_AGENT" ] || die "template not found: $TPL_AGENT"
+[ -f "$TPL_SKILL" ] || die "template not found: $TPL_SKILL"
+
+grep -qF "self-noops on changes with no sensitive surface" "$TPL_AGENT" || \
+  die "template at $PLUGIN_DIR is not v0.9.4 (missing the sharpened agent description). Update the plugin first."
+
+command -v python3 >/dev/null 2>&1 || die "python3 is required for the surgical frontmatter/body patch."
+
+# --- Idempotency -------------------------------------------------------------
+already_agent=no; already_skill=no
+grep -qF "self-noops on changes with no sensitive surface" "$SECAGENT" 2>/dev/null && already_agent=yes
+grep -qF "abuse-test recipe for" "$SECSKILL" 2>/dev/null && already_skill=yes
+if [ "$already_agent" = yes ] && [ "$already_skill" = yes ]; then
+  log "already at v0.9.4 (both security files carry the v0.9.4 markers) — nothing to do."
+  exit 0
+fi
+
+# --- Discover this project's substituted name --------------------------------
+# The "# Security Audit — <name>" heading of the installed skill is untouched by
+# v0.9.4, so it holds the substituted name in every v0.9.3 install.
+PROJ="$(sed -n 's/^# Security Audit — \(.*\)$/\1/p' "$SECSKILL" | head -1)"
+if [ -z "$PROJ" ]; then
+  PROJ="$(sed -n "s/.*checklist for \(.*\) — trust-boundary.*/\1/p" "$SECSKILL" | head -1)"
+fi
+[ -n "$PROJ" ] || die "could not discover this project's substituted name; aborting rather than write '{project}' literally."
+log "project name discovered: $PROJ"
+
+if [ "$DRY_RUN" = yes ]; then
+  log "DRY RUN — would:"
+  log "  1. back up $SECAGENT and $SECSKILL"
+  log "  2. replace the description: line of both from the v0.9.4 template (project='$PROJ')"
+  log "  3. re-splice 2 body spans of $SECAGENT (P0 rubric, repo-audit delta 5)"
+  exit 0
+fi
+
+if [ "$SKIP_PROMPT" != yes ]; then
+  printf "Apply the v0.9.4 security-skill patch to %s and %s? [y/N] " "$SECAGENT" "$SECSKILL"
+  read -r reply
+  case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 0 ;; esac
+fi
+
+cp "$SECAGENT" "$SECAGENT.pre-v0.9.4.bak"
+cp "$SECSKILL" "$SECSKILL.pre-v0.9.4.bak"
+log "backed up -> $SECAGENT.pre-v0.9.4.bak , $SECSKILL.pre-v0.9.4.bak"
+
+# Record which body spans the ORIGINAL file actually carried. A span whose anchor
+# is absent was customised by the project; the patch deliberately leaves it alone,
+# so its post-check must WARN rather than fail — a hard error there would tell the
+# user to restore from backup after a skip we chose on purpose.
+SPAN_P0=no; SPAN_D5=no
+grep -qE '^- \*\*P0\*\* — a client can move money' "$SECAGENT.pre-v0.9.4.bak" && SPAN_P0=yes
+grep -qE '^5\. \*\*Findings do not block\.\*\*' "$SECAGENT.pre-v0.9.4.bak" && SPAN_D5=yes
+
+PROJ="$PROJ" TPL_AGENT="$TPL_AGENT" TPL_SKILL="$TPL_SKILL" \
+SECAGENT="$SECAGENT" SECSKILL="$SECSKILL" python3 <<'PY'
+import os, re, sys
+
+proj = os.environ["PROJ"]
+
+def read(p):
+    with open(p, encoding="utf-8") as f:
+        return f.read()
+
+def write(p, s):
+    with open(p, "w", encoding="utf-8") as f:
+        f.write(s)
+
+DESC = re.compile(r"(?m)^description:.*$")
+
+def desc_of(text, what):
+    """The single-line `description:` entry inside the leading frontmatter."""
+    if not text.startswith("---"):
+        sys.exit("ERROR: %s has no leading frontmatter" % what)
+    end = text.index("\n---", 3)
+    m = DESC.search(text, 0, end)
+    if not m:
+        sys.exit("ERROR: could not locate a description: line in %s frontmatter" % what)
+    return m.group(0)
+
+def replace_desc(inst, tpl, name):
+    """Swap only the description LINE. Never rewrite frontmatter wholesale — an
+    `inherit` tools-mode install has had its `tools:` line stripped, and copying
+    the template's frontmatter would silently reintroduce it."""
+    old = desc_of(inst, "installed " + name)
+    new = desc_of(tpl, "template " + name).replace("{project}", proj)
+    return inst.replace(old, new, 1), (old != new)
+
+def span(text, start_re, end_re, what):
+    m = re.search(r"(?ms)^" + start_re + r".*?(?=^" + end_re + r")", text)
+    if not m:
+        return None
+    return m.group(0)
+
+def replace_span(inst, tpl, start_re, end_re, what):
+    t = span(tpl, start_re, end_re, what)
+    if t is None:
+        sys.exit("ERROR: template missing span %r" % what)
+    i = span(inst, start_re, end_re, what)
+    if i is None:
+        print("  WARN: install missing span %r — customised? leaving it alone." % what)
+        return inst, False
+    if i == t:
+        return inst, False
+    return inst.replace(i, t, 1), True
+
+# --- agent -------------------------------------------------------------------
+inst = read(os.environ["SECAGENT"])
+tpl = read(os.environ["TPL_AGENT"])
+changed = 0
+
+inst, c = replace_desc(inst, tpl, "harness-security"); changed += c
+
+inst, c = replace_span(
+    inst, tpl,
+    r"- \*\*P0\*\* — a client can move money",
+    r"- \*\*P1\*\*",
+    "Priority Rubric P0 bullet",
+); changed += c
+
+inst, c = replace_span(
+    inst, tpl,
+    r"5\. \*\*Findings do not block\.\*\*",
+    r"[ \t]*$",
+    "Repo-Audit Mode delta 5",
+); changed += c
+
+if "{project}" in inst:
+    sys.exit("ERROR: refusing to write a literal {project} into the agent")
+write(os.environ["SECAGENT"], inst)
+print("  harness-security: %d region(s) updated" % changed)
+
+# --- skill -------------------------------------------------------------------
+inst = read(os.environ["SECSKILL"])
+tpl = read(os.environ["TPL_SKILL"])
+inst, c = replace_desc(inst, tpl, "espalier-security")
+if "{project}" in inst:
+    sys.exit("ERROR: refusing to write a literal {project} into the skill")
+write(os.environ["SECSKILL"], inst)
+print("  espalier-security: description updated" if c else "  espalier-security: already current")
+PY
+rc=$?
+if [ $rc -ne 0 ]; then
+  die "surgical patch failed — restore from $SECAGENT.pre-v0.9.4.bak / $SECSKILL.pre-v0.9.4.bak"
+fi
+
+# --- Verify ------------------------------------------------------------------
+pass=0; fail=0; warn=0
+check() { if eval "$2" >/dev/null 2>&1; then pass=$((pass+1)); echo "  ✓ $1"; else fail=$((fail+1)); echo "  ✗ $1"; fi; }
+warn_check() { if eval "$2" >/dev/null 2>&1; then pass=$((pass+1)); echo "  ✓ $1"; else warn=$((warn+1)); echo "  ! $1 (span was customised — update it by hand)"; fi; }
+# A span the install carries MUST be patched; one it customised away is warn-only.
+span_check() { if [ "$1" = yes ]; then check "$2" "$3"; else warn_check "$2" "$3"; fi; }
+
+log "verification"
+check "agent description sharpened"     "grep -qF 'self-noops on changes with no sensitive surface' $SECAGENT"
+span_check "$SPAN_P0" "agent P0 rubric cross-refs mode" "grep -qF 'see Repo-Audit Mode, delta 5' $SECAGENT"
+span_check "$SPAN_D5" "agent delta 5 dedup'd"           "grep -qF 'Priority Rubric bar unchanged' $SECAGENT"
+check "skill description sharpened"     "grep -qF 'abuse-test recipe for' $SECSKILL"
+check "skill kept the project name"     "grep -qF '$PROJ' $SECSKILL"
+check "no literal {project} in agent"   "! grep -qF '{project}' $SECAGENT"
+check "no literal {project} in skill"   "! grep -qF '{project}' $SECSKILL"
+check "agent kept its VERDICT sentinel" "grep -q '^VERDICT:' $SECAGENT || grep -qF 'VERDICT:' $SECAGENT"
+check "agent kept Repo-Audit Mode"      "grep -qF '## Repo-Audit Mode' $SECAGENT"
+# `tools:` must not be reintroduced into an inherit-mode install: it had no
+# tools: line before, and the template does.
+if grep -qF 'tools:' "$SECAGENT.pre-v0.9.4.bak"; then
+  check "agent kept its tools: line"    "grep -qF 'tools:' $SECAGENT"
+else
+  check "agent stayed tools-less (inherit mode)" "! grep -qF 'tools:' $SECAGENT"
+fi
+
+echo
+log "Verification: $pass passed, $fail failed, $warn warn-only"
+[ "$fail" -eq 0 ] || die "verification failed — restore from the .pre-v0.9.4.bak files."
+if [ "$warn" -gt 0 ]; then
+  log "$warn customised span(s) left untouched — the v0.9.4 wording is a clarity"
+  log "improvement, not a behaviour change, so this is safe to leave or hand-merge."
+fi
+log "v0.9.4 migration complete. Backups: *.pre-v0.9.4.bak (delete when satisfied)."

--- a/skills/espalier-migrate/SKILL.md
+++ b/skills/espalier-migrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: espalier-migrate
-description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5, the v0.5.3 coder-agent patch, v0.5→v0.6 (Stage 1 grill), v0.6→v0.7 (read-only /espalier-ask lane), v0.7→v0.8 (requirements approval gate), the v0.8.1 impact-analysis agent patch, the v0.8.2 re-review fixpoint loop, the v0.9.0 security audit, the v0.9.1 configurable escalation caps, and the v0.9.2 correctness patch you need and applies them in order.
+description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5, the v0.5.3 coder-agent patch, v0.5→v0.6 (Stage 1 grill), v0.6→v0.7 (read-only /espalier-ask lane), v0.7→v0.8 (requirements approval gate), the v0.8.1 impact-analysis agent patch, the v0.8.2 re-review fixpoint loop, the v0.9.0 security audit, the v0.9.1 configurable escalation caps, the v0.9.2 correctness patch, the v0.9.3 skill-clarity patch, and the v0.9.4 security-skill patch you need and applies them in order.
 ---
 
 # Espalier Migration Runner
@@ -18,7 +18,7 @@ description: Migrate an existing harness/espalier install to the current Espalie
 ## Instructions
 
 You are running a migration of an existing install to the current Espalier
-version. Up to TWELVE migrations may apply, always in this order:
+version. Up to FOURTEEN migrations may apply, always in this order:
 
 1. **v0.1.x → v0.2.x** — typed `harness/changes/{type}/{slug}/` layout,
    `/harness-fix` lane, squash-merge decision. Mechanical:
@@ -104,16 +104,29 @@ version. Up to TWELVE migrations may apply, always in this order:
    production-readiness checklist (`production-standards.md` is the single source),
    and gains when-to-use + trigger phrases in its frontmatter. Backs both skills up
    to `<file>.pre-v0.9.3.bak`. Mechanical: `scripts/migrate-v0.9.2-to-v0.9.3.sh`.
+14. **v0.9.3 → v0.9.4** — security-skill patch; no new lane, no new stage, no
+   behaviour change to any gate or verdict (the security auditor's catch /
+   false-positive rates are unchanged). The per-project `harness-security` AGENT
+   and `espalier-security` SKILL gain when-to-use + the five sensitive axes as
+   frontmatter trigger context, and the agent's P0 rubric and repo-audit
+   "findings do not block" delta stop restating each other's semantics,
+   cross-referencing one source instead. Both are per-project files that
+   `bootstrap --force` never re-copies, so v0.9.4 shipped these template
+   improvements with no way to reach an existing install. Frontmatter is edited
+   LINE-WISE (an `inherit` tools-mode install has had its `tools:` line stripped;
+   re-copying the template's frontmatter would reintroduce it). A body span the
+   project has customised is left alone and reported warn-only. Backs both up to
+   `<file>.pre-v0.9.4.bak`. Mechanical: `scripts/migrate-v0.9.3-to-v0.9.4.sh`.
 
 Your job: detect which one(s) apply, locate the scripts, preview, get
-confirmation, apply in order. A v0.1.x install needs ALL THIRTEEN; a v0.3.x
-install needs the last twelve; a v0.4.x install needs the last eleven; a
-v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.9.3; a v0.5.3–v0.5.x
-install needs v0.6 … v0.9.3; a v0.6.x install needs v0.7 … v0.9.3; a v0.7.x
-install needs v0.8 … v0.9.3; a v0.8.0 install needs v0.8.1 … v0.9.3; a v0.8.1
-install needs v0.8.2 … v0.9.3; a v0.8.2 install needs v0.9.0 … v0.9.3; a
-v0.9.0 install needs v0.9.1 … v0.9.3; a v0.9.1 install needs v0.9.2 then v0.9.3;
-a v0.9.2 install needs only v0.9.3.
+confirmation, apply in order. A v0.1.x install needs ALL FOURTEEN; a v0.3.x
+install needs the last thirteen; a v0.4.x install needs the last twelve; a
+v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.9.4; a v0.5.3–v0.5.x
+install needs v0.6 … v0.9.4; a v0.6.x install needs v0.7 … v0.9.4; a v0.7.x
+install needs v0.8 … v0.9.4; a v0.8.0 install needs v0.8.1 … v0.9.4; a v0.8.1
+install needs v0.8.2 … v0.9.4; a v0.8.2 install needs v0.9.0 … v0.9.4; a
+v0.9.0 install needs v0.9.1 … v0.9.4; a v0.9.1 install needs v0.9.2 … v0.9.4;
+a v0.9.2 install needs v0.9.3 then v0.9.4; a v0.9.3 install needs only v0.9.4.
 
 Note: `migrate-v0.9.2-to-v0.9.3.sh` requires the installed `espalier-review`
 SKILL to carry a `## Production-Readiness Checks` section. Fresh v0.9.0+ inits
@@ -140,6 +153,7 @@ NEEDS_V09_MINOR=no
 NEEDS_V091_PATCH=no
 NEEDS_V092_PATCH=no
 NEEDS_V093_PATCH=no
+NEEDS_V094_PATCH=no
 
 if [ ! -d "harness" ] && [ ! -d "espalier" ]; then
   echo "ERROR: no harness/ or espalier/ dir found — not a target install."
@@ -164,6 +178,7 @@ if [ -d "harness" ]; then
   NEEDS_V091_PATCH=yes       # ...then the v0.9.1 configurable escalation caps
   NEEDS_V092_PATCH=yes       # ...then the v0.9.2 correctness patch
   NEEDS_V093_PATCH=yes       # ...then the v0.9.3 skill-clarity patch
+  NEEDS_V094_PATCH=yes       # ...then the v0.9.4 security-skill patch
 elif [ -d "espalier" ]; then
   # Already renamed. v0.4.x still needs the doc-drift upgrade.
   if [ ! -f "espalier/hooks/drift-detect.sh" ] || [ ! -f "espalier/.doctor-cadence" ]; then
@@ -257,6 +272,21 @@ elif [ -d "espalier" ]; then
      || ! grep -qF "SINGLE SOURCE for these checks" espalier/skills/espalier-review/SKILL.md 2>/dev/null; then
     NEEDS_V093_PATCH=yes
   fi
+  # v0.9.4: security-skill patch. Same two markers migrate-v0.9.3-to-v0.9.4.sh uses
+  # for its own idempotency check — keep them in sync with that script:
+  #   harness-security AGENT   → "self-noops on changes with no sensitive surface"
+  #   espalier-security SKILL  → "abuse-test recipe for"
+  # Both are per-project files a plugin update cannot reach. Either missing ⇒
+  # pre-v0.9.4. Guarded on the files existing: a pre-v0.9.0 install has neither,
+  # and the v0.9.0 step creates them before this step runs.
+  if [ -f espalier/agents/harness-security.md ] && [ -f espalier/skills/espalier-security/SKILL.md ]; then
+    if ! grep -qF "self-noops on changes with no sensitive surface" espalier/agents/harness-security.md 2>/dev/null \
+       || ! grep -qF "abuse-test recipe for" espalier/skills/espalier-security/SKILL.md 2>/dev/null; then
+      NEEDS_V094_PATCH=yes
+    fi
+  else
+    NEEDS_V094_PATCH=yes   # v0.9.0 will create them; v0.9.4 then sharpens them
+  fi
 fi
 
 if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
@@ -265,7 +295,7 @@ if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
    && [ "$NEEDS_V07_V08" = no ] && [ "$NEEDS_V08_PATCH" = no ] \
    && [ "$NEEDS_V082_PATCH" = no ] && [ "$NEEDS_V09_MINOR" = no ] \
    && [ "$NEEDS_V091_PATCH" = no ] && [ "$NEEDS_V092_PATCH" = no ] \
-   && [ "$NEEDS_V093_PATCH" = no ]; then
+   && [ "$NEEDS_V093_PATCH" = no ] && [ "$NEEDS_V094_PATCH" = no ]; then
   echo "Already fully up to date. Nothing to do."
   exit 0
 fi
@@ -286,7 +316,7 @@ never a stray `$HOME` checkout that merely shares the name.
 PLUGIN_DIR=""
 # Primary: derive the plugin root from the skill's own location.
 if [ -n "${CLAUDE_SKILL_DIR:-}" ] \
-   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.9.2-to-v0.9.3.sh" ]; then
+   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.9.3-to-v0.9.4.sh" ]; then
   PLUGIN_DIR="$(cd "${CLAUDE_SKILL_DIR}/../.." && pwd)"
 fi
 
@@ -295,7 +325,7 @@ fi
 if [ -z "$PLUGIN_DIR" ]; then
   for candidate in "${ESPALIER_PLUGIN_DIR:-}" "$HOME/repos/espalier-engineering"; do
     [ -n "$candidate" ] || continue
-    if [ -f "$candidate/scripts/migrate-v0.9.2-to-v0.9.3.sh" ]; then
+    if [ -f "$candidate/scripts/migrate-v0.9.3-to-v0.9.4.sh" ]; then
       PLUGIN_DIR="$candidate"
       break
     fi
@@ -313,7 +343,7 @@ fi
 The probe is the NEWEST migration script, so a plugin that predates the current
 chain fails to resolve rather than resolving and then dying on a missing script
 mid-apply. If the primary path misses and the fallback fires, the plugin install
-is likely stale (no `migrate-v0.9.2-to-v0.9.3.sh`) — tell the user to
+is likely stale (no `migrate-v0.9.3-to-v0.9.4.sh`) — tell the user to
 `/plugin update espalier-engineering` first. Bump this probe whenever a new
 migration script is added.
 
@@ -336,6 +366,7 @@ verbatim:
 [ "$NEEDS_V091_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.0-to-v0.9.1.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V092_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.1-to-v0.9.2.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V093_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.2-to-v0.9.3.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
+[ "$NEEDS_V094_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.3-to-v0.9.4.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 ```
 
 A dry-run for a step whose prerequisite has not been applied yet may refuse with
@@ -394,6 +425,7 @@ completed.
 [ "$NEEDS_V091_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.0-to-v0.9.1.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V092_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.1-to-v0.9.2.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V093_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.2-to-v0.9.3.sh" --yes --plugin-dir="$PLUGIN_DIR"
+[ "$NEEDS_V094_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.9.3-to-v0.9.4.sh" --yes --plugin-dir="$PLUGIN_DIR"
 ```
 
 Each script's verification block prints `X passed, Y failed`. Surface every
@@ -630,6 +662,30 @@ Fails closed with `ERROR: install missing section` if the installed
 `espalier-review` lacks `## Production-Readiness Checks`. That means the v0.9.0
 step never ran (or ran from a build predating its review-skill patch) — re-run the
 v0.9.0 step, which is idempotent and adds the section.
+
+**v0.9.3→v0.9.4 (`migrate-v0.9.3-to-v0.9.4.sh`):**
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Show actions only |
+| `--yes` | Skip the apply confirmation prompt |
+| `--plugin-dir=<path>` | Path to the espalier-engineering plugin checkout |
+
+Backs up `harness-security.md` + `espalier-security` SKILL (`<file>.pre-v0.9.4.bak`),
+then replaces the `description:` frontmatter line of each from the v0.9.4 template
+(substituting this project's name into the skill's), and re-splices the two changed
+body spans of the agent (P0 rubric, repo-audit delta 5). Requires `python3`.
+Idempotent — re-running detects both v0.9.4 markers and no-ops.
+
+Frontmatter is edited **line-wise, never rewritten**: an install created in
+`inherit` tools-mode has had its `tools:` line stripped, and copying the template's
+frontmatter would silently reintroduce it. The verification asserts the install's
+original tools-mode is preserved.
+
+A body span whose anchor the project has customised away is left untouched and
+reported **warn-only** (not `✗`), because the v0.9.4 wording is a clarity
+improvement, not a behaviour change. The script still exits 0 and still applies
+every span it could match.
 
 ## Anti-Patterns
 


### PR DESCRIPTION
Same bug class as v0.9.5: an improvement lands in the init templates, and nothing carries it to installs that already exist.

## New: `scripts/migrate-v0.9.3-to-v0.9.4.sh`

v0.9.4 (`059da7d`) sharpened two **per-project** files — the `harness-security` agent and the `espalier-security` skill — and shipped no migration script. Both are created at init (or by `migrate-v0.8.2-to-v0.9.0.sh`) with `{project}` substituted, so `bootstrap --force` never re-copies them and a plugin update cannot reach them. **No existing install ever received those improvements.**

The script re-splices exactly the changed regions:

- the `description:` frontmatter line of each file, from the v0.9.4 template, substituting the project name into the skill's;
- the agent's `## Priority Rubric` P0 bullet and its Repo-Audit Mode "findings do not block" delta, which now cross-reference one source rather than restating each other.

### Two deliberate non-behaviours

**Frontmatter is edited line-wise, never rewritten.** An install created in `inherit` tools-mode has had its `tools:` line stripped; the template still has one. Copying template frontmatter would silently reintroduce it. Verification asserts the install's original tools-mode survived, both ways.

**A customised body span is warn-only, not `✗`.** My first cut warned *"leaving it alone"* and then hard-failed verification, telling the user to restore from backup after a skip the script chose on purpose — the exact failure mode I criticised in v0.9.2's gate check. Now: span present ⇒ must patch (`check`); span customised away ⇒ `warn_check`, exit 0, customisation preserved, every other span still applied.

## Fixed: `espalier-migrate`'s frontmatter description was stale

v0.9.5 wired the v0.9.3 step into the skill's *body* — detection, dry-run, apply, prose, flags — but left the `description:` line enumerating migrations only through "the v0.9.2 correctness patch". That line is what Claude reads to decide whether to invoke the skill. Now lists v0.9.3 + v0.9.4; "Up to TWELVE migrations" → FOURTEEN.

## Verification

- **Patched agent is byte-identical to a fresh v0.9.4 init**, once `{project_name}` is substituted and `tools:` stripped for inherit mode. Tested against the real security files from a migrated install, not a synthetic one.
- Clean install: 10/10 checks, exit 0. Customised-span install: 9 pass / 0 fail / 1 warn, exit 0, customisation preserved, skill still upgraded.
- Idempotent — re-run detects both markers and no-ops.
- Detector: a v0.9.3-era install reports `V094=yes` and nothing else; a v0.9.4 install reports `V094=no`.
- `scripts/test-bootstrap.sh` 60/60. All four `SKILL.md` bash blocks pass `bash -n`.