### PR TITLE
v0.15.0 — Codex + Copilot platform support: espalier wiring goes three-platform

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,8 +3,8 @@
   "owner": {
     "name": "Zayhan"
   },
-  "description": "Marketplace publishing the Espalier Engineering plugin — auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.13.2",
+  "description": "Marketplace publishing the Espalier Engineering plugin \u2014 auto-discovered, project-specific guardrails for AI coding agents",
+  "version": "0.14.0",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -12,8 +12,8 @@
         "source": "github",
         "repo": "Junhanliu-dev/espalier-engineering"
       },
-      "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.13.2",
+      "description": "Train your AI coders the way you'd train a vine \u2014 discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
+      "version": "0.14.0",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Zayhan"
   },
   "description": "Marketplace publishing the Espalier Engineering plugin \u2014 auto-discovered, project-specific guardrails for AI coding agents",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "plugins": [
     {
       "name": "espalier-engineering",
@@ -13,7 +13,7 @@
         "repo": "Junhanliu-dev/espalier-engineering"
       },
       "description": "Train your AI coders the way you'd train a vine \u2014 discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "author": {
         "name": "Zayhan"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
-  "description": "Train your AI coders the way you'd train a vine — discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.13.2",
+  "description": "Train your AI coders the way you'd train a vine \u2014 discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
+  "version": "0.14.0",
   "author": {
     "name": "Zayhan"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "espalier-engineering",
   "description": "Train your AI coders the way you'd train a vine \u2014 discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "author": {
     "name": "Zayhan"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.15.0 — 2026-08-03
+
+Minor: **GitHub Copilot platform support** — the wiring layer goes
+three-platform. `--platforms` (and espalier-init's platform question) now
+accepts any subset of `claude`, `codex`, `copilot` (shorthands `both` /
+`all`); the `espalier/` tree stays the single platform-neutral source of
+truth. Additive as ever: `espalier/.platforms` unions, nothing unwires,
+claude-only output stays byte-stable. Suites: bootstrap 117/117 (+3-platform,
+copilot-only, idempotent-re-run fixtures), hooks 86/86 (+adapter payload
+matrix); validation is 46/51/56 by platform set.
+
+- **`scripts/bootstrap-espalier.sh`** — new stages: 7c appends the
+  `## Espalier` section to `.github/copilot-instructions.md` (grep-guarded;
+  always-read-rules instruction + Copilot platform-mapping table:
+  `@harness-*` custom agents, per-surface hook caveats); 8d writes
+  `.github/agents/harness-{coder,reviewer,security}.agent.md` custom agents
+  (write-if-absent; bodies point at the same `espalier/agents/*.md`); 8e
+  writes `.github/hooks/espalier-gates.json` (own file — user hook files
+  untouched; write-if-absent; self-heals the adapter copy on wire-only runs).
+  Stage 5 symlinks the 12 skills into `.github/skills/` — the one Agent
+  Skills location ALL Copilot surfaces read (VS Code, CLI, cloud coding
+  agent). Validation: checks 52-56; totals 46/51/56 with codex's 47-51
+  skip-rendered when only copilot forces the range, keeping numbering
+  contiguous.
+- **`hook-templates/copilot-hook-adapter.sh`** (new) — translates Copilot's
+  camelCase hook payload (`toolName`/`toolArgs`, incl. `path`/`filePath` →
+  `file_path`) into the Claude/Codex shape and dispatches to the shared
+  wrappers; exit codes pass through (Copilot fails non-zero `preToolUse`
+  exits closed — the exit-2 contract carries over). Without python it passes
+  the raw payload through, preserving the push gate's grep fast-path and
+  fail-closed probe. Missing wrapper → exit 0, never bricks a session.
+- **`skills/espalier-init/SKILL.md`** — Q4 becomes multiSelect across the
+  three platforms; Phase 3/Phase 4 and the "Running under Codex or Copilot"
+  fallback table extended (Copilot user-scope install via `~/.copilot/skills`).
+- **`skills/espalier-migrate/SKILL.md` + `scripts/migrate-v0.14.0-to-v0.15.0.sh`**
+  — migration #22: always installs the adapter (one new file, no backups
+  needed); `--with-copilot` (asked in the skill's Step 4c) wires copilot
+  additively via `bootstrap --wire-only`.
+- **Docs** — `docs/copilot-integration.md` (surfaces matrix incl. the
+  VS Code-runs-no-hooks gap, adapter contract, troubleshooting),
+  `docs/migrating-v0.14-to-v0.15.md`, README Copilot install section;
+  `references/wiring.md` + `references/validation.md` extended.
+
 ## 0.14.0 — 2026-08-03
 
 Minor: **Codex platform support** — the same discovered guardrails wire into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 0.14.0 — 2026-08-03
+
+Minor: **Codex platform support** — the same discovered guardrails wire into
+OpenAI Codex as a first-class target. `espalier-init` gains a Phase 0 platform
+question (Claude Code / Codex / Both) and `bootstrap-espalier.sh` a
+`--platforms=` flag; the `espalier/` tree stays platform-neutral, only wiring
+differs. Additive + idempotent: `espalier/.platforms` records the set, re-runs
+union (adding codex later never unwires claude), and a complete pre-v0.14
+install is inferred as `claude`. Suites: bootstrap 97/97 (+3 codex tests),
+hooks 73/73 (+payload matrix), validation 51 checks on codex installs while
+claude-only output stays byte-stable at 46.
+
+- **`scripts/bootstrap-espalier.sh`** — new stages: 7b appends the `## Espalier`
+  section to `AGENTS.md` (grep-guarded; carries the always-read-rules
+  instruction — Codex has no auto-loaded rules dir — plus the platform-mapping
+  table: `AskUserQuestion` → chat, sub-agent spawn → `.codex/agents/`,
+  `/espalier*` → `$espalier*`); 8b appends a marker-guarded hook block to
+  `.codex/config.toml` (`PostToolUse ^(apply_patch|Edit|Write)$` →
+  post-edit-wrapper, `PreToolUse ^(Bash|shell|local_shell)$` →
+  pre-push-gate-wrapper — Codex shares Claude Code's hook JSON schema and
+  exit-2-blocks contract, so the same wrappers serve both; backup + valid-TOML
+  append); 8c writes `.codex/agents/harness-{coder,reviewer,security}.toml`
+  (write-if-absent — user model tuning survives; `developer_instructions`
+  point at the same `espalier/agents/*.md`). Stage 5 symlinks the 12 skills
+  into `.agents/skills/` (Codex repo-skill discovery; same folder-name ==
+  frontmatter-name invariant). Claude-only stages gate on the platform set;
+  codex-only installs create no `.claude/` litter. `--wire-only` now reuses a
+  persisted `--merge-decision` and runs `stage_mkdirs`, so "add a platform
+  later" is one flag. Validation: checks 47-51 (codex wiring), dynamic totals,
+  claude checks skip (or swap to `espalier/`-source equivalents) when claude
+  is not targeted.
+- **`hook-templates/post-edit-wrapper.sh`** — platform-neutral: uses
+  `tool_input.file_path` when present, else extracts every
+  `*** Add|Update File:` path from the apply_patch body (string or argv
+  array); checks each file, exit 2 if any violates; repo root from
+  `$CLAUDE_PROJECT_DIR` else `git rev-parse --show-toplevel`.
+- **`hook-templates/pre-push-gate-wrapper.sh`** — joins argv-array commands
+  before the push-pattern match (the Python-list rendering would have been
+  eaten by the quote-span stripper and failed OPEN); `CLAUDE_PROJECT_DIR`
+  fallback is now unset-safe.
+- **`skills/espalier-init/SKILL.md`** — Phase 0 Q4 (platforms), Phase 3
+  `--platforms=` flag + `${CLAUDE_SKILL_DIR}` Codex fallback, Phase 4
+  codex trust steps in the completion message, and a "Running under Codex"
+  fallback table so `$espalier-init` runs from inside Codex itself.
+- **`skills/espalier-migrate/SKILL.md` + `scripts/migrate-v0.13.2-to-v0.14.0.sh`**
+  — migration #21: always refreshes the two wrappers (backups
+  `<file>.pre-v0.14.bak`); `--with-codex` (asked in the skill's Step 4b)
+  wires codex additively via `bootstrap --wire-only`.
+- **Docs** — `docs/codex-integration.md` (surfaces, trust model, degradations,
+  troubleshooting), `docs/migrating-v0.13-to-v0.14.md`, README Codex install
+  section; `references/wiring.md` + `references/validation.md` extended.
+
 ## 0.13.2 — 2026-07-23
 
 Patch: **the readability release** — "human readable" stops being an accident

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 /espalier-init
 ```
 
+> **v0.15.0 — Espalier learns Copilot; the wiring layer goes three-platform.** `/espalier-init` now targets any subset of **Claude Code, Codex, and GitHub Copilot**. For Copilot the same `espalier/` tree wires through Copilot-native surfaces: the 12 skills as **Agent Skills** in `.github/skills/` (read by VS Code, Copilot CLI, and the cloud coding agent; invoked `/espalier…`), the always-loaded rules via a generated `.github/copilot-instructions.md` section, coder/reviewer/security separation as `@harness-*` **custom agents** (`.github/agents/*.agent.md`), and the two quality gates as **Copilot hooks** (`.github/hooks/espalier-gates.json`) — a small adapter translates Copilot's camelCase hook payload into the Claude/Codex shape, so the *same* two wrapper scripts now gate all three platforms (Copilot fails non-zero `preToolUse` exits closed, matching the exit-2 contract). Wiring stays additive (`espalier/.platforms` unions; nothing ever unwires) and claude-only output stays byte-stable. Suites: bootstrap 117/117, hooks 86/86; validation is 46/51/56 checks by platform set. Setup guide: [`docs/copilot-integration.md`](./docs/copilot-integration.md).
+>
+> **Existing users:** run `/espalier-migrate` — the v0.15 step installs the one new adapter file and asks whether to wire Copilot. See [`docs/migrating-v0.14-to-v0.15.md`](./docs/migrating-v0.14-to-v0.15.md).
+
 > **v0.14.0 — Espalier learns Codex.** The same discovered guardrails now wire into **OpenAI Codex** as first-class output: `/espalier-init` asks which platform(s) to target (Claude Code, Codex, or both) and, for Codex, wires the very same `espalier/` content through Codex-native surfaces — the 12 skills as repo skills in `.agents/skills/` (invoked `$espalier`, `$espalier-fix`, …), the always-loaded rules via a generated `AGENTS.md` section, the coder/reviewer/security separation as `.codex/agents/harness-*.toml` subagents, and the two quality gates as `PreToolUse`/`PostToolUse` hooks in `.codex/config.toml` (Codex shares Claude Code's hook JSON schema and exit-2-blocks contract, so the *same* wrapper scripts serve both — now hardened to parse `apply_patch` patch bodies and argv-array commands). You can even run `$espalier-init` from inside Codex itself: the skill carries a platform-fallback table (chat questions instead of `AskUserQuestion`, inline discovery instead of scout spawns). Wiring is additive and re-runnable — a claude-only install adds codex later with one `--wire-only --platforms=codex` run (or `/espalier-migrate`), never unwiring anything. Suites extended and green: bootstrap 97/97, hooks 73/73, validation grows to 51 checks on codex installs while claude-only output stays byte-stable at 46. Setup guide: [`docs/codex-integration.md`](./docs/codex-integration.md).
 >
 > **Existing users:** run `/espalier-migrate`. It applies the chain (… v0.12.0→v0.13.0→v0.13.1→v0.13.2→v0.14.0) in order; the v0.14 step refreshes the two hook wrappers (backups at `<file>.pre-v0.14.bak`) and asks whether to wire Codex — declining changes nothing else. See [`docs/migrating-v0.13-to-v0.14.md`](./docs/migrating-v0.13-to-v0.14.md).
@@ -49,6 +53,7 @@ Plus platform wiring for whichever agent(s) you target (`--platforms`, asked at 
 
 - **Claude Code** — symlinks into `.claude/{rules,skills,agents}` so everything auto-loads, plus a `.claude/settings.json` hook entry for the quality gates.
 - **Codex** (v0.14.0) — symlinks into `.agents/skills/` (repo-skill discovery; invoke `$espalier` etc.), an `## Espalier` section in `AGENTS.md` (always-read rules instruction + platform mapping), `.codex/agents/harness-*.toml` subagents, and the same two quality-gate hooks in `.codex/config.toml`. See [`docs/codex-integration.md`](./docs/codex-integration.md).
+- **GitHub Copilot** (v0.15.0) — symlinks into `.github/skills/` (Agent Skills for VS Code, Copilot CLI, and the cloud coding agent; invoke `/espalier` etc.), an `## Espalier` section in `.github/copilot-instructions.md`, `@harness-*` custom agents in `.github/agents/`, and the same two gates as Copilot hooks in `.github/hooks/espalier-gates.json` (CLI + cloud agent). See [`docs/copilot-integration.md`](./docs/copilot-integration.md).
 
 The `espalier/` directory itself is platform-neutral — one source of truth however many agents read it.
 
@@ -170,6 +175,32 @@ bash ~/repos/espalier-engineering/scripts/bootstrap-espalier.sh \
 
 Full guide (what lands where, trust model, degradations): [`docs/codex-integration.md`](./docs/codex-integration.md).
 
+### GitHub Copilot install
+
+Copilot reads Agent Skills from user scope too — link the init skill there:
+
+```bash
+git clone https://github.com/Junhanliu-dev/espalier-engineering ~/repos/espalier-engineering
+mkdir -p ~/.copilot/skills
+ln -sfn ~/repos/espalier-engineering/skills/espalier-init    ~/.copilot/skills/espalier-init
+ln -sfn ~/repos/espalier-engineering/skills/espalier-migrate ~/.copilot/skills/espalier-migrate
+```
+
+Reload VS Code (or restart Copilot CLI), then in your project run
+`/espalier-init` and include **GitHub Copilot** at the platform question.
+After init, pipelines are `/espalier <requirement>`, `/espalier-fix <bug>`,
+etc., and sub-agents are `@harness-coder` / `@harness-reviewer` /
+`@harness-security`. Add Copilot to an existing install without redoing
+discovery:
+
+```bash
+bash ~/repos/espalier-engineering/scripts/bootstrap-espalier.sh \
+  --wire-only --platforms=copilot \
+  --plugin-dir=~/repos/espalier-engineering/skills/espalier-init --yes
+```
+
+Full guide (per-surface matrix, adapter, degradations): [`docs/copilot-integration.md`](./docs/copilot-integration.md).
+
 ## How `/espalier-init` Works
 
 On a fresh repo (~150 source files, medium size), expect **10-15 minutes**. It's a one-time tax — every future `/espalier` and `/espalier-fix` reuses the generated structure. You earn the time back inside the first few requirements via dropped rework rounds.
@@ -177,7 +208,7 @@ On a fresh repo (~150 source files, medium size), expect **10-15 minutes**. It's
 - **Phase 0 (front-loaded prompts)** — one `AskUserQuestion` captures squash-merge strategy, sub-agent tool scope, and doctor-scan cadence.
 - **Phase 1 (parallel discovery)** — single message fires ~11 concurrent tool calls: bash batch (tldr / manifests / git log), 6 scouts (architecture, coding patterns, testing, git+CI, unwritten rules, security surface), 1 oracle (ctx7 + WebSearch in parallel), 3 wiki scouts (data models, critical paths, external services).
 - **Phase 2 (parallel writes)** — one Write batch produces ~14 substitution files from the in-context DISCOVERY blob.
-- **Phase 3 (bootstrap)** — `scripts/bootstrap-espalier.sh` runs as one bash invocation: mkdir + copies + chmod + safe symlinks + atomic `.claude/settings.json` merge (preserves user hooks) + codex wiring when targeted (AGENTS.md section, `.codex/config.toml` hooks, `.codex/agents/*.toml`) + squash-merge decision + post-merge dispatcher install + .gitignore + 46 validation checks (51 with codex).
+- **Phase 3 (bootstrap)** — `scripts/bootstrap-espalier.sh` runs as one bash invocation: mkdir + copies + chmod + safe symlinks + atomic `.claude/settings.json` merge (preserves user hooks) + codex wiring when targeted (AGENTS.md section, `.codex/config.toml` hooks, `.codex/agents/*.toml`) + copilot wiring when targeted (`.github/copilot-instructions.md` section, `.github/skills/` links, `.github/agents/*.agent.md`, `.github/hooks/espalier-gates.json`) + squash-merge decision + post-merge dispatcher install + .gitignore + 46 validation checks (51 with codex, 56 with copilot).
 
 Total: ~5-7 batched turns, ~25-35 raw tool calls.
 
@@ -195,7 +226,7 @@ The skill never modifies its own source — it only writes content into the proj
 ```bash
 bash scripts/bootstrap-espalier.sh --copy-only      # Stages 1-4 only (dirs + cp templates + hooks)
 bash scripts/bootstrap-espalier.sh --wire-only      # Stages 5-11 only (symlinks + wiring + validation)
-bash scripts/bootstrap-espalier.sh --validate-only  # Stage 11 only (46 checks; 51 with codex — no changes)
+bash scripts/bootstrap-espalier.sh --validate-only  # Stage 11 only (46/51/56 checks by platform set — no changes)
 bash scripts/bootstrap-espalier.sh --dry-run        # Print actions without executing
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 /espalier-init
 ```
 
+> **v0.14.0 — Espalier learns Codex.** The same discovered guardrails now wire into **OpenAI Codex** as first-class output: `/espalier-init` asks which platform(s) to target (Claude Code, Codex, or both) and, for Codex, wires the very same `espalier/` content through Codex-native surfaces — the 12 skills as repo skills in `.agents/skills/` (invoked `$espalier`, `$espalier-fix`, …), the always-loaded rules via a generated `AGENTS.md` section, the coder/reviewer/security separation as `.codex/agents/harness-*.toml` subagents, and the two quality gates as `PreToolUse`/`PostToolUse` hooks in `.codex/config.toml` (Codex shares Claude Code's hook JSON schema and exit-2-blocks contract, so the *same* wrapper scripts serve both — now hardened to parse `apply_patch` patch bodies and argv-array commands). You can even run `$espalier-init` from inside Codex itself: the skill carries a platform-fallback table (chat questions instead of `AskUserQuestion`, inline discovery instead of scout spawns). Wiring is additive and re-runnable — a claude-only install adds codex later with one `--wire-only --platforms=codex` run (or `/espalier-migrate`), never unwiring anything. Suites extended and green: bootstrap 97/97, hooks 73/73, validation grows to 51 checks on codex installs while claude-only output stays byte-stable at 46. Setup guide: [`docs/codex-integration.md`](./docs/codex-integration.md).
+>
+> **Existing users:** run `/espalier-migrate`. It applies the chain (… v0.12.0→v0.13.0→v0.13.1→v0.13.2→v0.14.0) in order; the v0.14 step refreshes the two hook wrappers (backups at `<file>.pre-v0.14.bak`) and asks whether to wire Codex — declining changes nothing else. See [`docs/migrating-v0.13-to-v0.14.md`](./docs/migrating-v0.13-to-v0.14.md).
+
 > **v0.13.0 — the coder gets a laziness ladder; the reviewer gets a minimalism lens.** Espalier enforced *fit* — conventions, layers, production seeds — but had no notion of *size*: a convention-perfect 200-line date-picker component passed every gate while `<input type="date">` was never considered. Now the coder climbs a **Solution Selection Ladder** before choosing a change's shape (reuse what the project has → the convention-named mechanism → stdlib/native/installed dep → the leanest compliant implementation; a NEW dependency needs a `requirements.md` line), and the reviewer runs an **advisory Minimalism Review** — `delete:`/`stdlib:`/`native:`/`yagni:` findings capped at **P2/P3** so they can never re-open the Stage 4 fixpoint loop, with ONE objectively-checkable P1: a new dependency covering what stdlib or an installed dep already provides. The governing rule everywhere: **conventions first, correctness within them, brevity only breaks ties** — a construct your rules mandate is never "over-build", and "the convention itself is bloat" routes to the human promotion path, never a blocking finding. Idea adapted from [ponytail](https://github.com/DietrichGebert/ponytail) (MIT), re-grounded convention-first. Gated on both eval suites (coder **4/4** incl. a new overbuild-trap fixture; review **8/8**, catch-rate 1.00, FP 0 — incl. a planted new-dependency P1 and a severity-inflation guard) and quality-scored by independent agents on the darwin 8-dimension rubric: **avg 82.3 → 85.9** after the scorer-finding fix round (reviewer 91.0, coder 88.6). Full report: [`docs/quality-report-v0.13.0.md`](./docs/quality-report-v0.13.0.md).
 >
 > **Existing users:** run `/espalier-migrate`. It auto-detects your install version and applies the needed migration chain (… v0.10.0→v0.11.0→v0.12.0→v0.13.0) in order. The v0.12→v0.13 step is surgical (anchored section inserts into the four per-project coder/reviewer files — never a template overwrite, backups at `<file>.pre-v0.13.bak`). See [`docs/migrating-v0.12-to-v0.13.md`](./docs/migrating-v0.12-to-v0.13.md).
@@ -28,7 +32,7 @@ Result: **rework cycles drop from 3-5 rounds to typically 1.**
 
 ## What It Generates
 
-After running `/espalier-init` on any repo, you get a per-project `espalier/` directory wired into Claude Code:
+After running `/espalier-init` on any repo, you get a per-project `espalier/` directory wired into your agent platform(s) — Claude Code, Codex, or both:
 
 ```
 espalier/
@@ -41,7 +45,12 @@ espalier/
 └── changes/                # typed audit trail: feat/, fix/, refactor/, docs/ — one dir per requirement
 ```
 
-Plus symlinks into `.claude/` so Claude Code discovers everything, plus a `.claude/settings.json` hook entry for the quality gates.
+Plus platform wiring for whichever agent(s) you target (`--platforms`, asked at init):
+
+- **Claude Code** — symlinks into `.claude/{rules,skills,agents}` so everything auto-loads, plus a `.claude/settings.json` hook entry for the quality gates.
+- **Codex** (v0.14.0) — symlinks into `.agents/skills/` (repo-skill discovery; invoke `$espalier` etc.), an `## Espalier` section in `AGENTS.md` (always-read rules instruction + platform mapping), `.codex/agents/harness-*.toml` subagents, and the same two quality-gate hooks in `.codex/config.toml`. See [`docs/codex-integration.md`](./docs/codex-integration.md).
+
+The `espalier/` directory itself is platform-neutral — one source of truth however many agents read it.
 
 ## The Two Pipelines
 
@@ -127,6 +136,40 @@ mkdir -p .claude/skills
 ln -sfn /path/to/espalier-engineering/skills/espalier-init .claude/skills/espalier-init
 ```
 
+### Codex (OpenAI) install
+
+Codex has no Claude plugin system — install the init skill as a user-scoped
+Codex skill instead:
+
+```bash
+git clone https://github.com/Junhanliu-dev/espalier-engineering ~/repos/espalier-engineering
+mkdir -p ~/.agents/skills
+ln -sfn ~/repos/espalier-engineering/skills/espalier-init    ~/.agents/skills/espalier-init
+ln -sfn ~/repos/espalier-engineering/skills/espalier-migrate ~/.agents/skills/espalier-migrate
+```
+
+Restart Codex, then in your project:
+
+```text
+$espalier-init
+```
+
+Pick **Codex** (or **Both**) at the platform question. After init: restart
+Codex, trust the project when prompted, and run `/hooks` once to trust the two
+Espalier quality gates. Pipelines are then `$espalier <requirement>`,
+`$espalier-fix <bug>`, `$espalier-ask <question>`, `$espalier-audit`.
+
+Already ran init from Claude Code? Add Codex wiring to the same repo without
+redoing discovery:
+
+```bash
+bash ~/repos/espalier-engineering/scripts/bootstrap-espalier.sh \
+  --wire-only --platforms=codex \
+  --plugin-dir=~/repos/espalier-engineering/skills/espalier-init --yes
+```
+
+Full guide (what lands where, trust model, degradations): [`docs/codex-integration.md`](./docs/codex-integration.md).
+
 ## How `/espalier-init` Works
 
 On a fresh repo (~150 source files, medium size), expect **10-15 minutes**. It's a one-time tax — every future `/espalier` and `/espalier-fix` reuses the generated structure. You earn the time back inside the first few requirements via dropped rework rounds.
@@ -134,7 +177,7 @@ On a fresh repo (~150 source files, medium size), expect **10-15 minutes**. It's
 - **Phase 0 (front-loaded prompts)** — one `AskUserQuestion` captures squash-merge strategy, sub-agent tool scope, and doctor-scan cadence.
 - **Phase 1 (parallel discovery)** — single message fires ~11 concurrent tool calls: bash batch (tldr / manifests / git log), 6 scouts (architecture, coding patterns, testing, git+CI, unwritten rules, security surface), 1 oracle (ctx7 + WebSearch in parallel), 3 wiki scouts (data models, critical paths, external services).
 - **Phase 2 (parallel writes)** — one Write batch produces ~14 substitution files from the in-context DISCOVERY blob.
-- **Phase 3 (bootstrap)** — `scripts/bootstrap-espalier.sh` runs as one bash invocation: mkdir + copies + chmod + safe symlinks + atomic `.claude/settings.json` merge (preserves user hooks) + squash-merge decision + post-merge dispatcher install + .gitignore + 46 validation checks.
+- **Phase 3 (bootstrap)** — `scripts/bootstrap-espalier.sh` runs as one bash invocation: mkdir + copies + chmod + safe symlinks + atomic `.claude/settings.json` merge (preserves user hooks) + codex wiring when targeted (AGENTS.md section, `.codex/config.toml` hooks, `.codex/agents/*.toml`) + squash-merge decision + post-merge dispatcher install + .gitignore + 46 validation checks (51 with codex).
 
 Total: ~5-7 batched turns, ~25-35 raw tool calls.
 
@@ -152,7 +195,7 @@ The skill never modifies its own source — it only writes content into the proj
 ```bash
 bash scripts/bootstrap-espalier.sh --copy-only      # Stages 1-4 only (dirs + cp templates + hooks)
 bash scripts/bootstrap-espalier.sh --wire-only      # Stages 5-11 only (symlinks + wiring + validation)
-bash scripts/bootstrap-espalier.sh --validate-only  # Stage 11 only (46 checks, no changes)
+bash scripts/bootstrap-espalier.sh --validate-only  # Stage 11 only (46 checks; 51 with codex — no changes)
 bash scripts/bootstrap-espalier.sh --dry-run        # Print actions without executing
 ```
 

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -1,0 +1,147 @@
+# Codex Integration (v0.14.0)
+
+Espalier's discovered guardrails are platform-neutral markdown + shell. Since
+v0.14.0, `espalier-init` wires them into **OpenAI Codex** as a first-class
+target alongside (or instead of) Claude Code. This doc covers what lands
+where, why, the trust steps Codex requires, and the known degradations.
+
+## Requirements
+
+A Codex CLI / IDE build recent enough to have all three of:
+
+| Feature | Espalier uses it for | Codex surface |
+|---|---|---|
+| Repo skills (`.agents/skills/`, `SKILL.md`) | the 12 espalier skills, incl. the `$espalier` / `$espalier-fix` orchestrators | skills discovery walks `.agents/skills/` from cwd up to the repo root |
+| Lifecycle hooks (`PreToolUse` / `PostToolUse`) | the push gate + layer-boundary check | `[[hooks.*]]` tables in `.codex/config.toml` (project layer) |
+| Subagents (`.codex/agents/*.toml`) | coder / reviewer / security separation | spawned by name from the pipeline skills |
+
+Older Codex builds degrade in order: without subagents the pipeline runs the
+roles inline in strict sequence (the AGENTS.md mapping section instructs how);
+without hooks the gates don't fire (the pipeline's in-skill gate checks still
+run — you lose only the programmatic backstop); without skills there is no
+`$espalier` entry point and Codex support is effectively unavailable.
+
+## What gets wired where
+
+`bash scripts/bootstrap-espalier.sh --platforms=codex` (or `claude,codex`;
+espalier-init passes this from its platform question) adds, on top of the
+platform-neutral `espalier/` tree:
+
+| Artifact | Path | Mechanism |
+|---|---|---|
+| 12 skills | `.agents/skills/<name>` → `../../espalier/skills/<name>` symlinks | Codex repo-skill discovery; folder name == `name:` frontmatter (same invariant as Claude Code, so the same source dirs serve both) |
+| Always-loaded rules | `## Espalier` section appended to `AGENTS.md` (grep-guarded, one per repo) | Codex has **no auto-loaded rules dir** (`.codex/rules/` holds command-approval `prefix_rule()` policies, not instructions) — the AGENTS.md section carries an explicit "read every file in `espalier/rules/` before writing or reviewing code" instruction, plus the platform-mapping table below |
+| Sub-agents | `.codex/agents/harness-{coder,reviewer,security}.toml` | each sets `name`, `description`, `sandbox_mode = "workspace-write"`, and `developer_instructions` pointing at the matching `espalier/agents/*.md`. Write-if-absent: your later `model` / `model_reasoning_effort` tuning survives re-runs. Reviewer/security keep their only-my-record-file write contract in the instructions (Codex has no per-tool allowlist for subagents) |
+| Quality gates | marker-guarded block in `.codex/config.toml` (`# >>> ESPALIER HOOKS v1 >>>` … `<<<`) | `PostToolUse` matcher `^(apply_patch\|Edit\|Write)$` → `espalier/hooks/post-edit-wrapper.sh`; `PreToolUse` matcher `^(Bash\|shell\|local_shell)$` → `espalier/hooks/pre-push-gate-wrapper.sh`. Backup of any pre-existing config.toml is taken first; appending `[[hooks.*]]` tables at EOF is always valid top-level TOML |
+| Platform record | `espalier/.platforms` | tracked; re-runs union (`--wire-only --platforms=codex` on a claude install → `claude,codex`, never unwires) |
+
+Git-level pieces (post-merge drift dispatcher, commit-index cache, `.gitignore`
+entries) are platform-independent and identical on both targets.
+
+### One wrapper set, two platforms
+
+Codex adopted Claude Code's hook contract: same stdin JSON (`tool_name`,
+`tool_input`, …), same **exit 2 + stderr = block/feedback** semantics. The two
+wrappers are shared, with v0.14.0 hardening for the Codex payload shapes:
+
+- `post-edit-wrapper.sh` — uses `tool_input.file_path` when present (Claude
+  Write/Edit); otherwise extracts every `*** Add File:` / `*** Update File:`
+  path from the `apply_patch` patch body (`tool_input.command` or `.input`),
+  checks each, and exits 2 if any violates. Repo root comes from
+  `$CLAUDE_PROJECT_DIR` when set, else `git rev-parse --show-toplevel`.
+- `pre-push-gate-wrapper.sh` — joins argv-array commands
+  (`["bash","-lc","git push"]`) into a plain string before the git-push
+  pattern match, so the quote-stripping heuristic can't be blinded by list
+  quoting (which would have failed OPEN).
+
+## Trust model (why the gates need two yeses)
+
+Codex refuses project-supplied config by default:
+
+1. **Project trust** — `.codex/` layers (config, hooks, project rules) load
+   only for a trusted project. Codex prompts on first open; accept it.
+2. **Hook trust** — non-managed hooks additionally require a one-time
+   `/hooks` approval inside Codex before they execute.
+
+Until both are given, the pipeline still works but the two programmatic gates
+are silent. `espalier-init`'s completion message repeats these steps whenever
+codex was wired.
+
+## Install paths
+
+### Fresh init from Codex
+
+```bash
+git clone https://github.com/Junhanliu-dev/espalier-engineering ~/repos/espalier-engineering
+mkdir -p ~/.agents/skills
+ln -sfn ~/repos/espalier-engineering/skills/espalier-init    ~/.agents/skills/espalier-init
+ln -sfn ~/repos/espalier-engineering/skills/espalier-migrate ~/.agents/skills/espalier-migrate
+# restart Codex, then in the target repo:
+#   $espalier-init
+```
+
+The init skill carries a Codex fallback table (SKILL.md → "Running under
+Codex"): setup questions arrive in chat instead of `AskUserQuestion`,
+discovery scouts run as Codex subagents or inline, and the bootstrap command
+substitutes the skill's own resolved directory for `${CLAUDE_SKILL_DIR}`.
+
+### Fresh init from Claude Code, Codex included
+
+Run `/espalier-init` as usual and answer **Both** at the platform question
+(Q4). Everything else is unchanged.
+
+### Add Codex to an existing install
+
+Either `/espalier-migrate` (asks about Codex in its v0.14.0 step), or directly:
+
+```bash
+bash <plugin>/scripts/bootstrap-espalier.sh --wire-only --platforms=codex \
+  --plugin-dir=<plugin>/skills/espalier-init --yes
+```
+
+`--merge-decision` is reused from `espalier/.merge-hook-decision`; the
+platform set unions; validation runs the full 51 checks (46 base + 5 codex).
+
+## Using the pipelines in Codex
+
+| Claude Code | Codex |
+|---|---|
+| `/espalier <requirement>` | `$espalier <requirement>` |
+| `/espalier-fix <bug>` | `$espalier-fix <bug>` |
+| `/espalier-ask <question>` | `$espalier-ask <question>` |
+| `/espalier-audit`, `/espalier-prune`, `/espalier-doctor` | `$espalier-audit`, `$espalier-prune`, `$espalier-doctor` |
+
+The generated `AGENTS.md` section carries the full mapping the skills rely on:
+`AskUserQuestion` → ask in chat and wait (and "can I ask in chat" is the
+interactivity test the approval gates key on); "spawn harness-coder with
+prompt X" → spawn the `.codex/agents/harness-coder.toml` subagent with the
+same prompt, or — if spawning is unavailable — run the roles inline in strict
+sequence, never letting the pass that wrote code approve it;
+`$CLAUDE_PROJECT_DIR` → the repo root.
+
+## Known degradations vs Claude Code
+
+- **Rules are instruction-loaded, not harness-loaded.** Claude Code injects
+  `.claude/rules/*` unconditionally; Codex loads the rules because AGENTS.md
+  says to. Same trust level as any other AGENTS.md instruction — in practice
+  Codex follows it, but it is an instruction, not a mechanism.
+- **Reviewer write restriction is contractual.** Claude Code narrows the
+  reviewer's toolset via `tools:` frontmatter; Codex subagents get
+  `sandbox_mode` only, so "write nothing but your record file" lives in
+  `developer_instructions` (as it already does in the agent .md body).
+- **`AGENTS.override.md` wins.** If someone adds a local
+  `AGENTS.override.md`, Codex prefers it over `AGENTS.md` — the Espalier
+  section (and its rules instruction) silently drops out. Copy the section
+  into the override file if you use one.
+- **Skill loading needs a restart.** Codex scans skills/config at startup;
+  after init or migrate, restart the session.
+
+## Troubleshooting
+
+| Symptom | Cause → fix |
+|---|---|
+| `$espalier` not recognized | Codex started before wiring, or repo skills not discovered → restart Codex in the repo root; `ls .agents/skills/` should show 12 entries |
+| Gates never fire | project untrusted, or hooks untrusted → trust the project, run `/hooks`, retry; verify the block exists: `grep 'ESPALIER HOOKS' .codex/config.toml` |
+| Push slipped through the gate | hook trust missing (above), or `ESPALIER_SKIP_GATE=1` exported |
+| Rules ignored | `AGENTS.override.md` shadowing, or the `## Espalier` section missing → `grep '## Espalier' AGENTS.md`; re-run bootstrap Stage 7b via `--wire-only` |
+| Wrong/duplicate skills in the picker | a same-named user-scope skill also installed (`~/.agents/skills/espalier-*`) — Codex lists both; remove the user-scope copy in project contexts |

--- a/docs/copilot-integration.md
+++ b/docs/copilot-integration.md
@@ -1,0 +1,101 @@
+# GitHub Copilot Integration (v0.15.0)
+
+Espalier's discovered guardrails wire into **GitHub Copilot** as a first-class
+target alongside Claude Code and Codex. Same `espalier/` source of truth,
+Copilot-native surfaces. This doc covers what lands where, per-surface
+behavior, and the known degradations.
+
+## What gets wired where
+
+`bash scripts/bootstrap-espalier.sh --platforms=copilot` (any combination with
+`claude`/`codex` works; espalier-init passes this from its platform question)
+adds, on top of the platform-neutral `espalier/` tree:
+
+| Artifact | Path | Mechanism |
+|---|---|---|
+| 12 skills | `.github/skills/<name>` → `../../espalier/skills/<name>` symlinks | Copilot **Agent Skills** — the one repo location ALL Copilot surfaces read (VS Code, Copilot CLI, cloud coding agent). Invoked `/espalier`, `/espalier-fix`, … or auto-loaded by description. Folder name == `name:` frontmatter, same invariant as Claude Code/Codex — so the same source dirs serve every platform. VS Code additionally reads `.claude/skills/` and `.agents/skills/`, so claude/codex wiring already covers VS Code by itself. |
+| Always-loaded rules | `## Espalier` section appended to `.github/copilot-instructions.md` (grep-guarded) | Copilot's repository custom instructions load into every chat/agent session; the section carries the explicit "read every file in `espalier/rules/` first" instruction plus the Copilot platform-mapping table. If AGENTS.md (codex wiring) is also present, Copilot reads both — the section says to follow the contract once. |
+| Sub-agents | `.github/agents/harness-{coder,reviewer,security}.agent.md` | Copilot **custom agents** (`@harness-coder` etc. in VS Code/CLI; selectable for cloud-agent runs). Frontmatter `name` + `description`; body points at the matching `espalier/agents/*.md`. Write-if-absent — your later `model`/`tools` tuning survives re-runs. Reviewer/security keep their only-my-record-file write contract in the body. |
+| Quality gates | `.github/hooks/espalier-gates.json` (own file — user hook files never touched; write-if-absent) | Copilot **hooks**: `preToolUse` matcher `bash\|shell` → push gate; `postToolUse` matcher `edit\|write\|create\|apply_patch\|str_replace_editor` → layer-boundary check. Each dispatches through `espalier/hooks/copilot-hook-adapter.sh`. |
+| Platform record | `espalier/.platforms` | tracked; unions on re-run — adding copilot never unwires claude/codex. |
+
+### The adapter: one wrapper set, three platforms
+
+Copilot hooks send a **camelCase** payload — `{"toolName": "bash",
+"toolArgs": {...}}` — where Claude Code and Codex send `tool_name` /
+`tool_input`. Rather than teach the two shared wrappers a third schema,
+`copilot-hook-adapter.sh` translates (including `path`/`filePath` →
+`file_path`) and pipes to the wrapper named in its argument. Exit codes pass
+through: Copilot treats a non-zero `preToolUse` exit as **DENY (fail-closed)**
+— so the wrappers' exit-2-blocks contract carries over unchanged. Without
+python the adapter passes the raw payload through: the push-gate wrapper's
+grep fast-path and fail-closed python probe still behave correctly.
+
+### Where the gates actually run
+
+| Surface | Skills | Custom agents | Hooks |
+|---|---|---|---|
+| Copilot CLI | ✓ | ✓ (`/agent`) | ✓ (auto-loaded from repo) |
+| Copilot cloud coding agent | ✓ | ✓ (assign/dropdown) | ✓ (sandbox) |
+| VS Code Copilot chat | ✓ | ✓ (`@name`) | ✗ — VS Code does not execute repo hooks; the pipeline's in-skill gate checks still apply |
+
+## Install paths
+
+### Fresh init, Copilot included
+
+Run `/espalier-init` (Claude Code) or `/espalier-init` via Copilot / `$espalier-init`
+via Codex, and include **GitHub Copilot** in the platform question. Everything
+else is unchanged.
+
+### Run espalier-init from Copilot itself
+
+```bash
+git clone https://github.com/Junhanliu-dev/espalier-engineering ~/repos/espalier-engineering
+mkdir -p ~/.copilot/skills
+ln -sfn ~/repos/espalier-engineering/skills/espalier-init    ~/.copilot/skills/espalier-init
+ln -sfn ~/repos/espalier-engineering/skills/espalier-migrate ~/.copilot/skills/espalier-migrate
+# reload VS Code / restart Copilot CLI, then in the target repo: /espalier-init
+```
+
+The init skill's platform-fallback table (SKILL.md → "Running under Codex or
+Copilot") applies: questions arrive in chat, discovery runs inline or via
+custom agents, and the bootstrap command substitutes the skill's own resolved
+directory for `${CLAUDE_SKILL_DIR}`.
+
+### Add Copilot to an existing install
+
+Either `/espalier-migrate` (asks about Copilot in its v0.15.0 step), or directly:
+
+```bash
+bash <plugin>/scripts/bootstrap-espalier.sh --wire-only --platforms=copilot \
+  --plugin-dir=<plugin>/skills/espalier-init --yes
+```
+
+`--merge-decision` is reused from `espalier/.merge-hook-decision`; the platform
+set unions; validation runs 56 checks (46 base + 5 codex slots + 5 copilot —
+codex slots render as skips when codex isn't wired).
+
+## Known degradations vs Claude Code
+
+- **Rules are instruction-loaded.** Copilot loads `copilot-instructions.md`
+  automatically, but the espalier rules load because that section says to
+  read them — an instruction, not a harness mechanism.
+- **Reviewer write restriction is contractual.** Custom agents accept a
+  `tools:` allowlist, but the generated agents omit it (the reviewer still
+  needs edit access for its record file); the restriction lives in the agent
+  body, as on Codex.
+- **VS Code chat runs no hooks.** The programmatic gates cover CLI + cloud
+  agent only. In VS Code, the pipeline's own stage gates (in-skill sentinel
+  checks) are the enforcement.
+- **Reload required.** Skills/agents/hooks register at session start — reload
+  VS Code or restart the CLI after wiring.
+
+## Troubleshooting
+
+| Symptom | Cause → fix |
+|---|---|
+| `/espalier` not in the skills picker | wiring predates the session → reload VS Code / restart CLI; `ls .github/skills/` should show 12 entries |
+| Duplicate skills in the picker | same-named user-scope copies (`~/.copilot/skills/`, `~/.claude/skills/`, `~/.agents/skills/`) alongside the repo ones — remove the user-scope duplicates |
+| Gates never fire in CLI | `.github/hooks/espalier-gates.json` missing or invalid JSON → re-run bootstrap Stage 8e; `python3 -c 'import json;json.load(open(".github/hooks/espalier-gates.json"))'` |
+| Gates "fire" in VS Code | they don't — VS Code chat executes no hooks; that's the documented gap, not a regression |
+| Every bash call denied in CLI | adapter crash = fail-closed deny → run `printf '{"toolName":"bash","toolArgs":{"command":"ls"}}' \| bash espalier/hooks/copilot-hook-adapter.sh pre-push-gate-wrapper.sh; echo $?` — expect 0 |

--- a/docs/migrating-v0.13-to-v0.14.md
+++ b/docs/migrating-v0.13-to-v0.14.md
@@ -1,0 +1,81 @@
+# Migrating from v0.13.2 to v0.14.0 (Codex Platform Support)
+
+## TL;DR
+
+```bash
+# 1. Update the plugin
+/plugin update espalier-engineering
+
+# 2. From inside Claude Code, in your target project:
+/espalier-migrate
+```
+
+Or run the script directly:
+
+```bash
+# from the target project root
+bash <plugin>/scripts/migrate-v0.13.2-to-v0.14.0.sh --dry-run                # preview
+bash <plugin>/scripts/migrate-v0.13.2-to-v0.14.0.sh --yes                    # wrappers only
+bash <plugin>/scripts/migrate-v0.13.2-to-v0.14.0.sh --with-codex --yes       # + wire Codex
+```
+
+## What v0.14.0 changes — and why
+
+Espalier's guardrails were always platform-neutral markdown + shell, but the
+*wiring* was Claude-Code-only: `.claude/` symlinks, `CLAUDE.md`,
+`settings.json` hooks. Teams with Codex users had the rules and no way to load
+them. v0.14.0 makes Codex a first-class wiring target — same `espalier/`
+source of truth, Codex-native surfaces:
+
+| Espalier artifact | Claude Code wiring | Codex wiring (new) |
+|---|---|---|
+| 12 skills | `.claude/skills/*` symlinks, `/espalier…` | `.agents/skills/*` symlinks, `$espalier…` |
+| 5 always-loaded rules | `.claude/rules/*` symlinks (harness-injected) | `AGENTS.md` `## Espalier` section with an explicit always-read instruction |
+| 3 sub-agents | `.claude/agents/*.md` | `.codex/agents/harness-*.toml` (`developer_instructions` → the same `.md` files) |
+| 2 quality gates | `.claude/settings.json` hooks | `.codex/config.toml` `[[hooks.*]]` block (same JSON schema, same exit-2 contract, same wrapper scripts) |
+
+Full design + trust model: [`codex-integration.md`](./codex-integration.md).
+
+## What the migration step does
+
+**Always (the actual v0.13.2→v0.14.0 delta on an existing install):** refreshes
+the two plugin-owned hook wrappers to their platform-neutral v0.14.0 versions —
+
+- `espalier/hooks/post-edit-wrapper.sh` — also parses Codex `apply_patch`
+  payloads (`*** Add|Update File:` lines, argv arrays) and resolves the repo
+  root via `git rev-parse` when `$CLAUDE_PROJECT_DIR` is unset. Checks every
+  file in a multi-file patch; exit 2 if any violates.
+- `espalier/hooks/pre-push-gate-wrapper.sh` — joins argv-array commands before
+  the git-push pattern match (a Python-list rendering would have been stripped
+  by the quote remover and failed OPEN).
+
+Both changes are inert under Claude Code — same fields, same exit codes.
+Backups land at `<file>.pre-v0.14.bak`.
+
+**Only with `--with-codex`** (the `/espalier-migrate` skill asks; declining
+changes nothing else): wires Codex additively via
+`bootstrap --wire-only --platforms=codex` — `.agents/skills/` symlinks,
+`AGENTS.md` section, `.codex/config.toml` hook block, `.codex/agents/*.toml`,
+`espalier/.platforms` (unioned to `claude,codex`). Validation grows to 51
+checks; claude wiring is never touched. Wire it later at any time with the
+same flag, or directly:
+
+```bash
+bash <plugin>/scripts/bootstrap-espalier.sh --wire-only --platforms=codex \
+  --plugin-dir=<plugin>/skills/espalier-init --yes
+```
+
+## After wiring Codex
+
+Three one-time steps inside Codex: restart it in the repo, trust the project
+when prompted, and run `/hooks` to trust the two gate commands. Then
+`$espalier <requirement>` runs the same 10-stage pipeline.
+
+## Idempotency + rollback
+
+The script is a no-op when the wrappers already carry the v0.14.0 markers
+(and, with `--with-codex`, when `espalier/.platforms` already lists codex).
+Rollback = restore the two `.pre-v0.14.bak` files; codex wiring is removable
+by deleting the marker block in `.codex/config.toml`, the `.agents/skills/`
+symlinks, `.codex/agents/harness-*.toml`, and the `## Espalier` section in
+`AGENTS.md` (and setting `espalier/.platforms` back to `claude`).

--- a/docs/migrating-v0.14-to-v0.15.md
+++ b/docs/migrating-v0.14-to-v0.15.md
@@ -1,0 +1,71 @@
+# Migrating from v0.14.0 to v0.15.0 (Copilot Platform Support)
+
+## TL;DR
+
+```bash
+# 1. Update the plugin
+/plugin update espalier-engineering
+
+# 2. From inside Claude Code, in your target project:
+/espalier-migrate
+```
+
+Or run the script directly:
+
+```bash
+# from the target project root
+bash <plugin>/scripts/migrate-v0.14.0-to-v0.15.0.sh --dry-run                  # preview
+bash <plugin>/scripts/migrate-v0.14.0-to-v0.15.0.sh --yes                      # adapter only
+bash <plugin>/scripts/migrate-v0.14.0-to-v0.15.0.sh --with-copilot --yes       # + wire Copilot
+```
+
+## What v0.15.0 changes — and why
+
+v0.14.0 made the wiring layer multi-platform (Claude Code + Codex). v0.15.0
+adds the third major agent: **GitHub Copilot** — same `espalier/` source of
+truth, Copilot-native surfaces:
+
+| Espalier artifact | Copilot wiring (new) |
+|---|---|
+| 12 skills | `.github/skills/*` symlinks — Agent Skills read by VS Code, Copilot CLI, AND the cloud coding agent; invoked `/espalier…` |
+| 5 always-loaded rules | `## Espalier` section in `.github/copilot-instructions.md` with an explicit always-read instruction |
+| 3 sub-agents | `.github/agents/harness-*.agent.md` custom agents (`@harness-coder` …) |
+| 2 quality gates | `.github/hooks/espalier-gates.json` → `copilot-hook-adapter.sh` → the same shared wrappers (Copilot sends camelCase `toolName`/`toolArgs`; the adapter translates; non-zero `preToolUse` exits deny, so the exit-2 contract carries over). Hooks run in CLI + cloud agent; VS Code chat runs no hooks. |
+
+Full design + per-surface matrix: [`copilot-integration.md`](./copilot-integration.md).
+
+## What the migration step does
+
+**Always (the actual v0.14.0→v0.15.0 delta on an existing install):** installs
+one NEW plugin-owned file — `espalier/hooks/copilot-hook-adapter.sh`. Nothing
+is modified, so there are no backups; the adapter is inert until Copilot hooks
+reference it.
+
+**Only with `--with-copilot`** (the `/espalier-migrate` skill asks; declining
+changes nothing else): wires Copilot additively via
+`bootstrap --wire-only --platforms=copilot` — `.github/skills/` symlinks,
+`copilot-instructions.md` section, `.github/agents/*.agent.md`,
+`.github/hooks/espalier-gates.json`, `espalier/.platforms` unioned. Validation
+becomes 56 checks. Claude/Codex wiring is never touched. Wire later anytime:
+
+```bash
+bash <plugin>/scripts/bootstrap-espalier.sh --wire-only --platforms=copilot \
+  --plugin-dir=<plugin>/skills/espalier-init --yes
+```
+
+## After wiring Copilot
+
+Reload VS Code (or restart Copilot CLI) so the skills/agents/hooks register.
+Then `/espalier <requirement>` in Copilot chat/CLI runs the same 10-stage
+pipeline; sub-agents are `@harness-coder` / `@harness-reviewer` /
+`@harness-security`.
+
+## Idempotency + rollback
+
+No-op when the adapter exists (and, with `--with-copilot`, when
+`espalier/.platforms` already lists copilot). Rollback = delete
+`espalier/hooks/copilot-hook-adapter.sh`; copilot wiring is removable by
+deleting `.github/hooks/espalier-gates.json`, the `.github/skills/` symlinks,
+`.github/agents/harness-*.agent.md`, the `## Espalier` section in
+`.github/copilot-instructions.md`, and dropping `copilot` from
+`espalier/.platforms`.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Espalier Engineering — train your AI coders like a vine</title>
-<meta name="description" content="Discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline — wired into Claude Code and OpenAI Codex — so generated code lands inside your conventions on the first try, not the fifth.">
+<meta name="description" content="Discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline — wired into Claude Code, OpenAI Codex, and GitHub Copilot — so generated code lands inside your conventions on the first try, not the fifth.">
 <meta property="og:title" content="Espalier Engineering">
 <meta property="og:description" content="Train your AI coders like you'd train a vine.">
 <meta property="og:type" content="website">
@@ -1131,7 +1131,7 @@ footer {
       Espalier
     </a>
     <div class="nav-right">
-      <span class="nav-pill">v0.14.0</span>
+      <span class="nav-pill">v0.15.0</span>
       <a href="#install">Install</a>
       <a href="#cost">Cost</a>
       <a href="https://github.com/Junhanliu-dev/espalier-engineering">GitHub →</a>
@@ -1745,6 +1745,9 @@ footer {
           Interactive-only — an unattended (no-TTY) run auto-approves so the pipeline never hangs. No new skill, no new stage.
         </div>
         <p style="color:var(--ink-muted); margin-top:32px; font-size:15px; line-height:1.6">
+          <span style="color:var(--paper)">v0.15.0</span> — Espalier learns Copilot; the wiring layer goes three-platform. <code style="font-family:var(--f-mono);color:var(--vine)">--platforms</code> now takes any subset of claude / codex / copilot. For <em>GitHub Copilot</em>: the 12 skills land as Agent Skills in <code style="font-family:var(--f-mono);color:var(--vine)">.github/skills/</code> (VS Code, Copilot CLI, and the cloud coding agent all read it; invoked <code style="font-family:var(--f-mono);color:var(--vine)">/espalier</code>&hellip;), the always-loaded rules ride a generated <code style="font-family:var(--f-mono);color:var(--vine)">.github/copilot-instructions.md</code> section, coder/reviewer/security separation becomes <code style="font-family:var(--f-mono);color:var(--vine)">@harness-*</code> custom agents, and the two quality gates install as Copilot hooks in <code style="font-family:var(--f-mono);color:var(--vine)">.github/hooks/espalier-gates.json</code> — a small adapter translates Copilot&rsquo;s camelCase payload so the <em>same</em> two wrapper scripts now gate all three platforms (non-zero preToolUse exits fail closed, matching the exit-2 contract). Additive wiring, byte-stable claude-only output. Suites: bootstrap 117/117, hooks 86/86; validation 46/51/56 by platform set. Existing users run <code style="font-family:var(--f-mono);color:var(--vine)">/espalier-migrate</code>.
+        </p>
+        <p style="color:var(--ink-muted); margin-top:16px; font-size:15px; line-height:1.6">
           <span style="color:var(--paper)">v0.14.0</span> — Espalier learns Codex. The same discovered guardrails wire into <em>OpenAI Codex</em> as a first-class target: the 12 skills land as repo skills in <code style="font-family:var(--f-mono);color:var(--vine)">.agents/skills/</code> (invoked <code style="font-family:var(--f-mono);color:var(--vine)">$espalier</code>, <code style="font-family:var(--f-mono);color:var(--vine)">$espalier-fix</code>, &hellip;), the always-loaded rules ride a generated <code style="font-family:var(--f-mono);color:var(--vine)">AGENTS.md</code> section, coder/reviewer/security separation becomes <code style="font-family:var(--f-mono);color:var(--vine)">.codex/agents/harness-*.toml</code> subagents, and the two quality gates install as <code style="font-family:var(--f-mono);color:var(--vine)">PreToolUse</code>/<code style="font-family:var(--f-mono);color:var(--vine)">PostToolUse</code> hooks in <code style="font-family:var(--f-mono);color:var(--vine)">.codex/config.toml</code> — Codex shares Claude Code&rsquo;s hook contract, so the <em>same</em> wrapper scripts serve both platforms. Init asks which platform(s) to wire (Claude Code / Codex / both); adding codex to an existing install is one additive <code style="font-family:var(--f-mono);color:var(--vine)">--wire-only</code> run that never unwires anything. Suites: bootstrap 97/97, hooks 73/73; validation grows to 51 checks on codex installs while claude-only output stays byte-stable. Existing users run <code style="font-family:var(--f-mono);color:var(--vine)">/espalier-migrate</code>.
         </p>
         <p style="color:var(--ink-muted); margin-top:16px; font-size:15px; line-height:1.6">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Espalier Engineering — train your AI coders like a vine</title>
-<meta name="description" content="Discover your codebase's actual patterns, then encode them as Claude Code rules, skills, agents, hooks, and a guided pipeline so generated code lands inside your conventions on the first try, not the fifth.">
+<meta name="description" content="Discover your codebase's actual patterns, then encode them as rules, skills, agents, hooks, and a guided pipeline — wired into Claude Code and OpenAI Codex — so generated code lands inside your conventions on the first try, not the fifth.">
 <meta property="og:title" content="Espalier Engineering">
 <meta property="og:description" content="Train your AI coders like you'd train a vine.">
 <meta property="og:type" content="website">
@@ -1131,7 +1131,7 @@ footer {
       Espalier
     </a>
     <div class="nav-right">
-      <span class="nav-pill">v0.13.0</span>
+      <span class="nav-pill">v0.14.0</span>
       <a href="#install">Install</a>
       <a href="#cost">Cost</a>
       <a href="https://github.com/Junhanliu-dev/espalier-engineering">GitHub →</a>
@@ -1745,6 +1745,9 @@ footer {
           Interactive-only — an unattended (no-TTY) run auto-approves so the pipeline never hangs. No new skill, no new stage.
         </div>
         <p style="color:var(--ink-muted); margin-top:32px; font-size:15px; line-height:1.6">
+          <span style="color:var(--paper)">v0.14.0</span> — Espalier learns Codex. The same discovered guardrails wire into <em>OpenAI Codex</em> as a first-class target: the 12 skills land as repo skills in <code style="font-family:var(--f-mono);color:var(--vine)">.agents/skills/</code> (invoked <code style="font-family:var(--f-mono);color:var(--vine)">$espalier</code>, <code style="font-family:var(--f-mono);color:var(--vine)">$espalier-fix</code>, &hellip;), the always-loaded rules ride a generated <code style="font-family:var(--f-mono);color:var(--vine)">AGENTS.md</code> section, coder/reviewer/security separation becomes <code style="font-family:var(--f-mono);color:var(--vine)">.codex/agents/harness-*.toml</code> subagents, and the two quality gates install as <code style="font-family:var(--f-mono);color:var(--vine)">PreToolUse</code>/<code style="font-family:var(--f-mono);color:var(--vine)">PostToolUse</code> hooks in <code style="font-family:var(--f-mono);color:var(--vine)">.codex/config.toml</code> — Codex shares Claude Code&rsquo;s hook contract, so the <em>same</em> wrapper scripts serve both platforms. Init asks which platform(s) to wire (Claude Code / Codex / both); adding codex to an existing install is one additive <code style="font-family:var(--f-mono);color:var(--vine)">--wire-only</code> run that never unwires anything. Suites: bootstrap 97/97, hooks 73/73; validation grows to 51 checks on codex installs while claude-only output stays byte-stable. Existing users run <code style="font-family:var(--f-mono);color:var(--vine)">/espalier-migrate</code>.
+        </p>
+        <p style="color:var(--ink-muted); margin-top:16px; font-size:15px; line-height:1.6">
           <span style="color:var(--paper)">v0.13.0</span> — the coder gets a laziness ladder; the reviewer gets a minimalism lens. Espalier enforced <em>fit</em> but had no notion of <em>size</em>: a convention-perfect 200-line date picker passed every gate while <code style="font-family:var(--f-mono);color:var(--vine)">&lt;input type="date"&gt;</code> was never considered. The coder now climbs a <em>Solution Selection Ladder</em> before choosing a change&rsquo;s shape — reuse what the project has &rarr; the convention-named mechanism &rarr; stdlib / native / installed dep &rarr; the leanest compliant implementation; a NEW dependency needs a <code style="font-family:var(--f-mono);color:var(--vine)">requirements.md</code> line. The reviewer runs an <em>advisory Minimalism Review</em>: <code style="font-family:var(--f-mono);color:var(--vine)">delete:/stdlib:/native:/yagni:</code> findings capped at P2/P3 so they can never re-open the Stage 4 loop, with one objectively-checkable P1 — a new dependency covering what stdlib or an installed dep already provides. Governing rule everywhere: <em>conventions first, correctness within them, brevity only breaks ties</em>. Idea adapted from <a href="https://github.com/DietrichGebert/ponytail" style="color:var(--vine)">ponytail</a> (MIT), re-grounded convention-first. Gated on both eval suites (coder 4/4 incl. an overbuild trap; review 8/8, catch-rate 1.00, FP 0) and quality-scored by independent agents — avg <em>82.3 &rarr; 85.9</em> after the fix round. Existing users run <code style="font-family:var(--f-mono);color:var(--vine)">/espalier-migrate</code>.
         </p>
         <p style="color:var(--ink-muted); margin-top:16px; font-size:15px; line-height:1.6">

--- a/scripts/bootstrap-espalier.sh
+++ b/scripts/bootstrap-espalier.sh
@@ -24,7 +24,11 @@
 #   - Appends .gitignore entries for the commit-index + drift sidecars.
 #   - Wires the codex platform when targeted (.agents/skills symlinks,
 #     AGENTS.md section, .codex/config.toml hooks, .codex/agents/*.toml).
-#   - Runs the validation checks (R6) — 46 claude-only, 51 with codex.
+#   - Wires the copilot platform when targeted (.github/skills symlinks,
+#     copilot-instructions.md section, .github/agents/*.agent.md,
+#     .github/hooks/espalier-gates.json via the camelCase adapter).
+#   - Runs the validation checks (R6) — 46 claude-only, 51 with codex,
+#     56 with copilot.
 #
 # Usage:
 #   bash bootstrap-espalier.sh --merge-decision=<val> [options]
@@ -40,11 +44,16 @@
 #   --lang=<typescript|python|go|unsupported>
 #                            Boundary-check variant. "unsupported" emits a no-op.
 #   --doctor-cadence=<val>   every-change | weekly | monthly | manual (default: weekly).
-#   --platforms=<list>       Comma list of agent platforms to wire: claude | codex
-#                            (or the shorthand "both"). Default: claude.
-#                            claude → .claude/ symlinks + CLAUDE.md + settings.json
-#                            codex  → .agents/skills/ symlinks + AGENTS.md +
-#                                     .codex/config.toml hooks + .codex/agents/*.toml
+#   --platforms=<list>       Comma list of agent platforms to wire:
+#                            claude | codex | copilot (shorthands: "both" =
+#                            claude,codex; "all" = all three). Default: claude.
+#                            claude  → .claude/ symlinks + CLAUDE.md + settings.json
+#                            codex   → .agents/skills/ symlinks + AGENTS.md +
+#                                      .codex/config.toml hooks + .codex/agents/*.toml
+#                            copilot → .github/skills/ symlinks +
+#                                      .github/copilot-instructions.md section +
+#                                      .github/agents/*.agent.md +
+#                                      .github/hooks/espalier-gates.json
 #   --dry-run                Print actions without executing.
 #   --yes                    Non-interactive (used by tests + CI smoke).
 #   --force                  Override re-run safety check on existing espalier/.
@@ -52,7 +61,7 @@
 # Debug flags (not used by normal /espalier-init flow):
 #   --copy-only              Only Stages 1-4 (mkdir + pure-copy + hooks).
 #   --wire-only              Only Stages 5-11 (symlinks + wiring + validation).
-#   --validate-only          Only Stage 11 (46/51-check validation).
+#   --validate-only          Only Stage 11 (46/51/56-check validation).
 #   --ignore-drift           Skip check #25's hard fail on expired (>90d) drift.
 #   --ignore-drift-reason=<s> Audit reason recorded with --ignore-drift.
 
@@ -91,7 +100,7 @@ for arg in "$@"; do
     --wire-only)            MODE="wire-only" ;;
     --validate-only)        MODE="validate-only" ;;
     -h|--help)
-      sed -n '2,57p' "$0"
+      sed -n '2,66p' "$0"
       exit 0
       ;;
     *)
@@ -239,24 +248,27 @@ esac
 # existing espalier/.platforms (re-runs are ADDITIVE — wiring codex later never
 # unwires claude) > persisted file alone > default claude.
 normalize_platforms() {
-  # stdin: comma list → stdout: canonical "claude"|"codex"|"claude,codex"; rc 1 on junk
-  local raw p want_c=no want_x=no
+  # stdin: comma list → stdout: canonical subset of "claude,codex,copilot"
+  # (that order); rc 1 on junk / empty
+  local raw p want_c=no want_x=no want_p=no out=""
   raw=$(cat | tr 'A-Z' 'a-z' | tr -d '[:space:]')
-  [ "$raw" = "both" ] && raw="claude,codex"
+  raw=${raw//both/claude,codex}
+  raw=${raw//all/claude,codex,copilot}
   local IFS=','
   for p in $raw; do
     case "$p" in
       claude)      want_c=yes ;;
       codex)       want_x=yes ;;
+      copilot)     want_p=yes ;;
       "")          ;;
       *)           return 1 ;;
     esac
   done
-  [ "$want_c" = "no" ] && [ "$want_x" = "no" ] && return 1
-  if [ "$want_c" = "yes" ] && [ "$want_x" = "yes" ]; then echo "claude,codex"
-  elif [ "$want_x" = "yes" ]; then echo "codex"
-  else echo "claude"
-  fi
+  [ "$want_c" = "yes" ] && out="claude"
+  [ "$want_x" = "yes" ] && out="${out:+$out,}codex"
+  [ "$want_p" = "yes" ] && out="${out:+$out,}copilot"
+  [ -z "$out" ] && return 1
+  echo "$out"
 }
 
 EXISTING_PLATFORMS=""
@@ -271,7 +283,7 @@ fi
 
 if [ -n "$PLATFORMS_FLAG" ]; then
   PLATFORMS=$(printf '%s,%s' "$PLATFORMS_FLAG" "$EXISTING_PLATFORMS" | normalize_platforms) || {
-    echo "ERROR: invalid --platforms='$PLATFORMS_FLAG' (valid: claude | codex | claude,codex | both)" >&2
+    echo "ERROR: invalid --platforms='$PLATFORMS_FLAG' (valid: any comma list of claude|codex|copilot, or both|all)" >&2
     exit 1
   }
 elif [ -n "$EXISTING_PLATFORMS" ]; then
@@ -280,8 +292,9 @@ else
   PLATFORMS="claude"
 fi
 
-want_claude() { case "$PLATFORMS" in *claude*) return 0 ;; *) return 1 ;; esac; }
-want_codex()  { case "$PLATFORMS" in *codex*)  return 0 ;; *) return 1 ;; esac; }
+want_claude()  { case "$PLATFORMS" in *claude*)  return 0 ;; *) return 1 ;; esac; }
+want_codex()   { case "$PLATFORMS" in *codex*)   return 0 ;; *) return 1 ;; esac; }
+want_copilot() { case "$PLATFORMS" in *copilot*) return 0 ;; *) return 1 ;; esac; }
 
 log "Mode: $MODE | project: $PROJECT_DIR | plugin: $PLUGIN_DIR | lang: $LANG_VARIANT | platforms: $PLATFORMS"
 
@@ -327,6 +340,11 @@ stage_mkdirs() {
     run "mkdir -p .agents/skills"
     run "mkdir -p .codex/agents"
   fi
+  if want_copilot; then
+    run "mkdir -p .github/skills"
+    run "mkdir -p .github/agents"
+    run "mkdir -p .github/hooks"
+  fi
 }
 
 # --- Stage 3: Pure-copy templates -------------------------------------------
@@ -361,6 +379,9 @@ stage_hooks() {
   run "cp '$PLUGIN_DIR/hook-templates/drift-detect.sh' espalier/hooks/drift-detect.sh"
   run "cp '$PLUGIN_DIR/hook-templates/drift-helpers.sh' espalier/hooks/drift-helpers.sh"
   run "cp '$PLUGIN_DIR/hook-templates/parse-drift-blocks.py' espalier/hooks/parse-drift-blocks.py"
+  # Copilot camelCase→snake_case hook shim (pure copy; inert unless
+  # .github/hooks/espalier-gates.json references it — Stage 8e, copilot only).
+  run "cp '$PLUGIN_DIR/hook-templates/copilot-hook-adapter.sh' espalier/hooks/copilot-hook-adapter.sh"
   # --lang=unsupported: guarantee post-edit-wrapper never execs a missing file.
   # Write-if-absent ONLY — never clobber a Phase-2-adapted hook.
   if [ "$LANG_VARIANT" = "unsupported" ] && [ ! -f espalier/hooks/check-layer-boundaries.sh ]; then
@@ -431,6 +452,24 @@ stage_symlinks() {
       WIRED_SKILLS=$CODEX_SKILLS
       WIRED_RULES=5    # bound via the AGENTS.md always-read instruction
       WIRED_AGENTS=3   # bound via .codex/agents/harness-*.toml
+    fi
+  fi
+  if want_copilot; then
+    # Copilot Agent Skills read .github/skills/ across ALL its surfaces
+    # (VS Code, CLI, cloud agent). VS Code additionally reads .claude/skills/
+    # and .agents/skills/, but .github/skills/ is the only cross-surface
+    # location — wire it explicitly, same invariant, invoked /espalier….
+    COPILOT_SKILLS=0
+    for s in $ESPALIER_SKILL_NAMES; do
+      safe_ln "../../espalier/skills/$s" ".github/skills/$s" && COPILOT_SKILLS=$((COPILOT_SKILLS+1))
+    done
+    log "  copilot: $COPILOT_SKILLS skills linked into .github/skills/"
+    # Rules load via the copilot-instructions.md instruction (Stage 7c) and
+    # sub-agents via .github/agents/*.agent.md (Stage 8d).
+    if ! want_claude && ! want_codex; then
+      WIRED_SKILLS=$COPILOT_SKILLS
+      WIRED_RULES=5    # bound via the copilot-instructions always-read instruction
+      WIRED_AGENTS=3   # bound via .github/agents/harness-*.agent.md
     fi
   fi
   # Read by espalier-init SKILL.md Phase 4 for the completion message — keep
@@ -786,6 +825,192 @@ SECURITYAGENT
   fi
 }
 
+# --- Stage 7c: .github/copilot-instructions.md append (copilot) --------------
+
+stage_copilot_instructions() {
+  if ! want_copilot; then
+    return
+  fi
+  log "Stage 7c: .github/copilot-instructions.md append (idempotent grep-guard)"
+  if [ -f .github/copilot-instructions.md ] && grep -q "## Espalier" .github/copilot-instructions.md 2>/dev/null; then
+    log "  copilot-instructions.md already has Espalier section — skipping"
+    return
+  fi
+  if [ "$DRY_RUN" = "yes" ]; then
+    echo "[dry-run] append Espalier section to .github/copilot-instructions.md"
+    return
+  fi
+  mkdir -p .github
+  cat >> .github/copilot-instructions.md << 'COPILOTTMPL'
+
+## Espalier
+
+This project uses Espalier for AI code quality — auto-discovered, project-specific guardrails.
+
+**Always-loaded rules:** before writing or reviewing ANY code, read every file in
+`espalier/rules/` (engineering-structure, coding-standards, development-process,
+security-standards, production-standards). This instruction IS the load
+mechanism — do not skip it. (If AGENTS.md also carries an `## Espalier`
+section, it is the same contract — follow it once.)
+
+**For any implementation work**, invoke the `espalier` skill (`/espalier <requirement>`) to execute the full pipeline.
+
+**For bug fixes**, invoke `/espalier-fix <bug>` — 7 stages (0–7, no Stage 2).
+
+**For questions** ("how does X work", "where is Y"), invoke `/espalier-ask <question>` — read-only, answers from espalier/ docs first.
+
+**For a repo-wide security audit**, invoke `/espalier-audit` — inventories trust-boundary defects to `espalier/wiki/security-audit.md`; dispatch fixes via `/espalier-fix`.
+
+**Agent definition:** Read `espalier/agent.md` for your operating instructions.
+
+**Key principle:** The coder agent and reviewer agent are ALWAYS separate.
+Never review your own code in the same invocation that wrote it.
+
+### Platform mapping (Copilot)
+
+Espalier's skill files use Claude Code vocabulary in places; on Copilot apply these mappings:
+
+- `/espalier*` slash commands → the same-named Agent Skills (wired in
+  `.github/skills/`; invoke via `/espalier…` in chat/CLI or let Copilot load
+  them by description).
+- `AskUserQuestion` → ask the user directly in chat and WAIT for the reply.
+  Where a skill says "if you can call AskUserQuestion you are interactive",
+  read it as: if you can ask the user in chat, you ARE interactive.
+- "Spawn sub-agent harness-coder / harness-reviewer / harness-security with
+  prompt X" → hand off to the matching custom agent (`@harness-coder`,
+  `@harness-reviewer`, `@harness-security` — defined in `.github/agents/`)
+  with the same prompt. If custom-agent handoff is unavailable in this
+  surface, execute the roles inline in strict sequence and NEVER let the pass
+  that wrote code also approve it: finish the coder role, then re-read
+  `espalier/agents/harness-reviewer.md` and review the actual diff as if you
+  had not written it.
+- `.claude/settings.json` hooks → wired as Copilot hooks in
+  `.github/hooks/espalier-gates.json` (Copilot CLI + cloud agent; VS Code
+  chat does not run hooks — the pipeline's in-skill gates still apply).
+- `$CLAUDE_PROJECT_DIR` in docs → the repo root (`git rev-parse --show-toplevel`).
+COPILOTTMPL
+}
+
+# --- Stage 8d: .github/agents/*.agent.md sub-agents (copilot) -----------------
+
+stage_copilot_agents() {
+  if ! want_copilot; then
+    return
+  fi
+  log "Stage 8d: .github/agents/harness-*.agent.md (write-if-absent)"
+  if [ "$DRY_RUN" = "yes" ]; then
+    echo "[dry-run] write .github/agents/harness-{coder,reviewer,security}.agent.md (if absent)"
+    return
+  fi
+  mkdir -p .github/agents
+
+  # Write-if-absent ONLY — user tuning (model, tools) survives re-bootstrap,
+  # same policy as the codex .toml sub-agents.
+  if [ ! -f .github/agents/harness-coder.agent.md ]; then
+    cat > .github/agents/harness-coder.agent.md << 'CODERAGENTMD'
+---
+name: harness-coder
+description: Espalier implementation sub-agent — writes code strictly inside espalier/ rules; never reviews its own work
+---
+
+You are the harness-coder. Read espalier/agents/harness-coder.md and follow it
+exactly. Before writing any code, read every file in espalier/rules/ and the
+skill file espalier/skills/espalier-coding/SKILL.md. You implement; you never
+review or approve your own output.
+CODERAGENTMD
+    log "  wrote .github/agents/harness-coder.agent.md"
+  else
+    log "  .github/agents/harness-coder.agent.md exists — preserving"
+  fi
+
+  if [ ! -f .github/agents/harness-reviewer.agent.md ]; then
+    cat > .github/agents/harness-reviewer.agent.md << 'REVIEWERAGENTMD'
+---
+name: harness-reviewer
+description: Espalier review sub-agent — reviews diffs against espalier/ rules; writes ONLY its own review-record file
+---
+
+You are the harness-reviewer. Read espalier/agents/harness-reviewer.md and
+follow it exactly. Your ONLY permitted write is your own review record file
+(review-record.md in the active espalier/changes/ dir) — never source, tests,
+or any other file. Review the diff as written by someone else.
+REVIEWERAGENTMD
+    log "  wrote .github/agents/harness-reviewer.agent.md"
+  else
+    log "  .github/agents/harness-reviewer.agent.md exists — preserving"
+  fi
+
+  if [ ! -f .github/agents/harness-security.agent.md ]; then
+    cat > .github/agents/harness-security.agent.md << 'SECURITYAGENTMD'
+---
+name: harness-security
+description: Espalier security sub-agent — trust-boundary review against espalier/rules/security-standards.md; writes ONLY its own security-record file
+---
+
+You are the harness-security agent. Read espalier/agents/harness-security.md
+and follow it exactly. Your ONLY permitted write is your own security record
+file (security-record.md in the active espalier/changes/ dir, or
+espalier/wiki/security-audit.md in repo-audit mode) — never source, tests, or
+any other file.
+SECURITYAGENTMD
+    log "  wrote .github/agents/harness-security.agent.md"
+  else
+    log "  .github/agents/harness-security.agent.md exists — preserving"
+  fi
+}
+
+# --- Stage 8e: .github/hooks/espalier-gates.json (copilot) --------------------
+
+stage_copilot_hooks() {
+  if ! want_copilot; then
+    return
+  fi
+  log "Stage 8e: .github/hooks/espalier-gates.json (write-if-absent)"
+  if [ "$DRY_RUN" = "yes" ]; then
+    echo "[dry-run] write .github/hooks/espalier-gates.json (if absent)"
+    return
+  fi
+  mkdir -p .github/hooks
+  # wire-only runs skip Stage 4 — make sure the adapter this json dispatches
+  # to actually exists before referencing it.
+  if [ ! -f espalier/hooks/copilot-hook-adapter.sh ] && [ -f "$PLUGIN_DIR/hook-templates/copilot-hook-adapter.sh" ]; then
+    cp "$PLUGIN_DIR/hook-templates/copilot-hook-adapter.sh" espalier/hooks/copilot-hook-adapter.sh
+    chmod +x espalier/hooks/copilot-hook-adapter.sh
+    log "  copied espalier/hooks/copilot-hook-adapter.sh (wire-only run)"
+  fi
+  # Own file — Copilot loads every .github/hooks/*.json, so user hook files
+  # are never touched. Write-if-absent: user edits (timeouts, matchers)
+  # survive re-bootstrap.
+  if [ -f .github/hooks/espalier-gates.json ]; then
+    log "  .github/hooks/espalier-gates.json exists — preserving"
+    return
+  fi
+  cat > .github/hooks/espalier-gates.json << 'COPILOTHOOKS'
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "matcher": "bash|shell",
+        "bash": "bash espalier/hooks/copilot-hook-adapter.sh pre-push-gate-wrapper.sh",
+        "timeoutSec": 30
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "matcher": "edit|write|create|apply_patch|str_replace_editor",
+        "bash": "bash espalier/hooks/copilot-hook-adapter.sh post-edit-wrapper.sh",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+COPILOTHOOKS
+  log "  wrote .github/hooks/espalier-gates.json"
+}
+
 # --- Stage 9: Squash-merge decision + post-merge dispatcher -----------------
 
 stage_merge_decision() {
@@ -990,9 +1215,15 @@ stage_gitignore() {
 # --- Stage 11: Validation (parallel — R6) -----------------------------------
 
 stage_validate() {
-  # Check count is platform-dependent: 46 base + 5 codex-wiring checks.
+  # Check count is platform-dependent: 46 base + 5 codex (47-51) + 5 copilot
+  # (52-56). Numbering is FIXED per platform; copilot without codex still
+  # renders 47-51 as skip lines so the sequence stays contiguous.
   local TOTAL_CHECKS=46
-  want_codex && TOTAL_CHECKS=51
+  if want_copilot; then
+    TOTAL_CHECKS=56
+  elif want_codex; then
+    TOTAL_CHECKS=51
+  fi
   log "Stage 11: validation ($TOTAL_CHECKS checks — R6; platforms: $PLATFORMS)"
   if [ "$DRY_RUN" = "yes" ]; then
     echo "[dry-run] would run $TOTAL_CHECKS validation checks (skipped — nothing to validate yet)"
@@ -1144,13 +1375,27 @@ stage_validate() {
   run_check 44 "wiki-external-services (fix: re-run espalier-init Phase 2)" 'test -f espalier/wiki/external-services.md' &
   run_check 45 "rules-development-process (fix: re-run espalier-init Phase 2)" 'test -f espalier/rules/development-process.md' &
   run_check 46 "layer-boundaries-hook (fix: Phase 2 writes it; --lang=unsupported writes a no-op)" 'test -f espalier/hooks/check-layer-boundaries.sh && test -x espalier/hooks/check-layer-boundaries.sh' &
-  # 47-51: codex wiring (only when codex is a target platform).
+  # 47-51: codex wiring (skip-rendered when copilot alone keeps numbering contiguous).
   if want_codex; then
     run_check 47 "codex-skills-load"   'ls -d .agents/skills/espalier-coding .agents/skills/espalier-review .agents/skills/espalier-security .agents/skills/espalier-testing .agents/skills/espalier-requirements .agents/skills/espalier-grill .agents/skills/espalier .agents/skills/espalier-fix .agents/skills/espalier-prune .agents/skills/espalier-doctor .agents/skills/espalier-ask .agents/skills/espalier-audit' &
     run_check 48 "codex-symlinks-valid" '[ -L .agents/skills/espalier ] && [ -e .agents/skills/espalier ]' &
     run_check 49 "codex-agents-toml"   'grep -q "^name = \"harness-coder\"" .codex/agents/harness-coder.toml && grep -q "^name = \"harness-reviewer\"" .codex/agents/harness-reviewer.toml && grep -q "^name = \"harness-security\"" .codex/agents/harness-security.toml' &
     run_check 50 "codex-hooks-configured" 'grep -q "espalier/hooks" .codex/config.toml' &
     run_check 51 "codex-agentsmd"      'grep -q "## Espalier" AGENTS.md' &
+  elif want_copilot; then
+    skip_check 47 "codex-skills-load"     "codex not targeted"
+    skip_check 48 "codex-symlinks-valid"  "codex not targeted"
+    skip_check 49 "codex-agents-toml"     "codex not targeted"
+    skip_check 50 "codex-hooks-configured" "codex not targeted"
+    skip_check 51 "codex-agentsmd"        "codex not targeted"
+  fi
+  # 52-56: copilot wiring (only when copilot is a target platform).
+  if want_copilot; then
+    run_check 52 "copilot-skills-load"  'ls -d .github/skills/espalier-coding .github/skills/espalier-review .github/skills/espalier-security .github/skills/espalier-testing .github/skills/espalier-requirements .github/skills/espalier-grill .github/skills/espalier .github/skills/espalier-fix .github/skills/espalier-prune .github/skills/espalier-doctor .github/skills/espalier-ask .github/skills/espalier-audit' &
+    run_check 53 "copilot-symlinks-valid" '[ -L .github/skills/espalier ] && [ -e .github/skills/espalier ]' &
+    run_check 54 "copilot-agents"       'grep -q "^name: harness-coder" .github/agents/harness-coder.agent.md && grep -q "^name: harness-reviewer" .github/agents/harness-reviewer.agent.md && grep -q "^name: harness-security" .github/agents/harness-security.agent.md' &
+    run_check 55 "copilot-hooks-json"   'python3 -c "import json; json.load(open(\".github/hooks/espalier-gates.json\"))" && grep -q "copilot-hook-adapter" .github/hooks/espalier-gates.json && test -x espalier/hooks/copilot-hook-adapter.sh' &
+    run_check 56 "copilot-instructions" 'grep -q "## Espalier" .github/copilot-instructions.md' &
   fi
 
   wait
@@ -1159,7 +1404,7 @@ stage_validate() {
   # must reach stdout, which the run_check harness discards), then 26-51.
   cat "$tmpdir"/0? "$tmpdir"/1? "$tmpdir"/2[0-4] 2>/dev/null
   run_check_25 || echo "fail" > "$tmpdir/25.fail"
-  cat "$tmpdir"/2[6-9] "$tmpdir"/3? "$tmpdir"/4[0-9] "$tmpdir"/5[0-1] 2>/dev/null
+  cat "$tmpdir"/2[6-9] "$tmpdir"/3? "$tmpdir"/4[0-9] "$tmpdir"/5[0-6] 2>/dev/null
 
   failed=$(ls "$tmpdir"/*.fail 2>/dev/null | wc -l | tr -d ' ')
   rm -rf "$tmpdir"
@@ -1183,9 +1428,12 @@ case "$MODE" in
     stage_state_template
     stage_claudemd
     stage_agentsmd
+    stage_copilot_instructions
     stage_settings_json
     stage_codex_config
     stage_codex_agents
+    stage_copilot_agents
+    stage_copilot_hooks
     stage_merge_decision
     stage_gitignore
     stage_validate
@@ -1202,9 +1450,12 @@ case "$MODE" in
     stage_state_template
     stage_claudemd
     stage_agentsmd
+    stage_copilot_instructions
     stage_settings_json
     stage_codex_config
     stage_codex_agents
+    stage_copilot_agents
+    stage_copilot_hooks
     stage_merge_decision
     stage_gitignore
     stage_validate

--- a/scripts/bootstrap-espalier.sh
+++ b/scripts/bootstrap-espalier.sh
@@ -22,7 +22,9 @@
 #   - Merges .claude/settings.json hooks (Appendix A algorithm).
 #   - Persists squash-merge decision + installs the post-merge dispatcher.
 #   - Appends .gitignore entries for the commit-index + drift sidecars.
-#   - Runs 46 validation checks (R6).
+#   - Wires the codex platform when targeted (.agents/skills symlinks,
+#     AGENTS.md section, .codex/config.toml hooks, .codex/agents/*.toml).
+#   - Runs the validation checks (R6) — 46 claude-only, 51 with codex.
 #
 # Usage:
 #   bash bootstrap-espalier.sh --merge-decision=<val> [options]
@@ -38,6 +40,11 @@
 #   --lang=<typescript|python|go|unsupported>
 #                            Boundary-check variant. "unsupported" emits a no-op.
 #   --doctor-cadence=<val>   every-change | weekly | monthly | manual (default: weekly).
+#   --platforms=<list>       Comma list of agent platforms to wire: claude | codex
+#                            (or the shorthand "both"). Default: claude.
+#                            claude → .claude/ symlinks + CLAUDE.md + settings.json
+#                            codex  → .agents/skills/ symlinks + AGENTS.md +
+#                                     .codex/config.toml hooks + .codex/agents/*.toml
 #   --dry-run                Print actions without executing.
 #   --yes                    Non-interactive (used by tests + CI smoke).
 #   --force                  Override re-run safety check on existing espalier/.
@@ -45,7 +52,7 @@
 # Debug flags (not used by normal /espalier-init flow):
 #   --copy-only              Only Stages 1-4 (mkdir + pure-copy + hooks).
 #   --wire-only              Only Stages 5-11 (symlinks + wiring + validation).
-#   --validate-only          Only Stage 11 (46-check validation).
+#   --validate-only          Only Stage 11 (46/51-check validation).
 #   --ignore-drift           Skip check #25's hard fail on expired (>90d) drift.
 #   --ignore-drift-reason=<s> Audit reason recorded with --ignore-drift.
 
@@ -63,6 +70,8 @@ FORCE=no
 IGNORE_DRIFT=no
 IGNORE_DRIFT_REASON=""
 DOCTOR_CADENCE=weekly
+PLATFORMS=""          # resolved after parsing: flag > espalier/.platforms > claude
+PLATFORMS_FLAG=""     # raw --platforms value (empty = not passed)
 MODE="full"  # full | copy-only | wire-only | validate-only
 
 for arg in "$@"; do
@@ -72,6 +81,7 @@ for arg in "$@"; do
     --lang=*)               LANG_VARIANT="${arg#--lang=}" ;;
     --merge-decision=*)     MERGE_DECISION="${arg#--merge-decision=}" ;;
     --doctor-cadence=*)     DOCTOR_CADENCE="${arg#--doctor-cadence=}" ;;
+    --platforms=*)          PLATFORMS_FLAG="${arg#--platforms=}" ;;
     --dry-run)              DRY_RUN=yes ;;
     --yes)                  SKIP_PROMPT=yes ;;
     --force)                FORCE=yes ;;
@@ -81,7 +91,7 @@ for arg in "$@"; do
     --wire-only)            MODE="wire-only" ;;
     --validate-only)        MODE="validate-only" ;;
     -h|--help)
-      sed -n '2,49p' "$0"
+      sed -n '2,57p' "$0"
       exit 0
       ;;
     *)
@@ -182,7 +192,13 @@ if [ "$MODE" = "full" ] && [ "$FORCE" != "yes" ]; then
   # Else: espalier/ may exist with partial LLM writes — proceed (fresh install).
 fi
 
-# Validate --merge-decision (required for full and wire-only)
+# Validate --merge-decision (required for full and wire-only).
+# wire-only convenience: an existing install already persisted the decision —
+# reuse it so "add a platform later" runs don't force the user to re-answer.
+if [ -z "$MERGE_DECISION" ] && [ "$MODE" = "wire-only" ] && [ -f espalier/.merge-hook-decision ]; then
+  MERGE_DECISION=$(head -1 espalier/.merge-hook-decision | tr -d '[:space:]')
+  log "wire-only: reusing persisted merge decision '$MERGE_DECISION' (espalier/.merge-hook-decision)"
+fi
 case "$MODE" in
   full|wire-only)
     case "$MERGE_DECISION" in
@@ -219,7 +235,55 @@ case "$DOCTOR_CADENCE" in
     ;;
 esac
 
-log "Mode: $MODE | project: $PROJECT_DIR | plugin: $PLUGIN_DIR | lang: $LANG_VARIANT"
+# Resolve + validate platforms. Precedence: --platforms flag > union with any
+# existing espalier/.platforms (re-runs are ADDITIVE — wiring codex later never
+# unwires claude) > persisted file alone > default claude.
+normalize_platforms() {
+  # stdin: comma list → stdout: canonical "claude"|"codex"|"claude,codex"; rc 1 on junk
+  local raw p want_c=no want_x=no
+  raw=$(cat | tr 'A-Z' 'a-z' | tr -d '[:space:]')
+  [ "$raw" = "both" ] && raw="claude,codex"
+  local IFS=','
+  for p in $raw; do
+    case "$p" in
+      claude)      want_c=yes ;;
+      codex)       want_x=yes ;;
+      "")          ;;
+      *)           return 1 ;;
+    esac
+  done
+  [ "$want_c" = "no" ] && [ "$want_x" = "no" ] && return 1
+  if [ "$want_c" = "yes" ] && [ "$want_x" = "yes" ]; then echo "claude,codex"
+  elif [ "$want_x" = "yes" ]; then echo "codex"
+  else echo "claude"
+  fi
+}
+
+EXISTING_PLATFORMS=""
+if [ -f espalier/.platforms ]; then
+  EXISTING_PLATFORMS=$(head -1 espalier/.platforms | tr -d '[:space:]')
+elif [ -f espalier/.merge-hook-decision ]; then
+  # Complete pre-v0.14 install: predates .platforms, so it is a claude install.
+  # Without this inference, "--wire-only --platforms=codex" on a legacy install
+  # would record codex-only and validation would stop checking claude wiring.
+  EXISTING_PLATFORMS="claude"
+fi
+
+if [ -n "$PLATFORMS_FLAG" ]; then
+  PLATFORMS=$(printf '%s,%s' "$PLATFORMS_FLAG" "$EXISTING_PLATFORMS" | normalize_platforms) || {
+    echo "ERROR: invalid --platforms='$PLATFORMS_FLAG' (valid: claude | codex | claude,codex | both)" >&2
+    exit 1
+  }
+elif [ -n "$EXISTING_PLATFORMS" ]; then
+  PLATFORMS=$(printf '%s' "$EXISTING_PLATFORMS" | normalize_platforms) || PLATFORMS="claude"
+else
+  PLATFORMS="claude"
+fi
+
+want_claude() { case "$PLATFORMS" in *claude*) return 0 ;; *) return 1 ;; esac; }
+want_codex()  { case "$PLATFORMS" in *codex*)  return 0 ;; *) return 1 ;; esac; }
+
+log "Mode: $MODE | project: $PROJECT_DIR | plugin: $PLUGIN_DIR | lang: $LANG_VARIANT | platforms: $PLATFORMS"
 
 # Resolve the --ignore-drift audit reason once (prompt only when interactive).
 if [ "$IGNORE_DRIFT" = "yes" ] && [ -z "$IGNORE_DRIFT_REASON" ]; then
@@ -254,9 +318,15 @@ stage_mkdirs() {
   run "mkdir -p espalier/changes/feat"
   run "mkdir -p espalier/changes/fix"
   run "mkdir -p espalier/changes/refactor"
-  run "mkdir -p .claude/rules"
-  run "mkdir -p .claude/skills"
-  run "mkdir -p .claude/agents"
+  if want_claude; then
+    run "mkdir -p .claude/rules"
+    run "mkdir -p .claude/skills"
+    run "mkdir -p .claude/agents"
+  fi
+  if want_codex; then
+    run "mkdir -p .agents/skills"
+    run "mkdir -p .codex/agents"
+  fi
 }
 
 # --- Stage 3: Pure-copy templates -------------------------------------------
@@ -314,8 +384,10 @@ stage_hooks() {
 
 # --- Stage 5: Symlinks ------------------------------------------------------
 
+ESPALIER_SKILL_NAMES="espalier-coding espalier-review espalier-security espalier-testing espalier-requirements espalier-grill espalier espalier-fix espalier-prune espalier-doctor espalier-ask espalier-audit"
+
 stage_symlinks() {
-  log "Stage 5: symlinks into .claude/ (safe + portable abspath)"
+  log "Stage 5: platform wiring symlinks ($PLATFORMS)"
   # chmod-glob also runs here (idempotent) so wire-only mode picks up
   # LLM-written hooks. Full mode already chmodded in Stage 4 — harmless re-chmod.
   if [ "$DRY_RUN" != "yes" ]; then
@@ -324,22 +396,43 @@ stage_symlinks() {
     done
   fi
   # Targets are RELATIVE to the symlink's own directory (.claude/{rules,skills,
-  # agents}/<link> is two levels below the repo root, hence ../../espalier/…) —
-  # a repo moved or checked out at another path keeps every link resolving.
+  # agents}/<link> and .agents/skills/<link> are two levels below the repo root,
+  # hence ../../espalier/…) — a repo moved or checked out at another path keeps
+  # every link resolving.
   WIRED_RULES=0; WIRED_SKILLS=0; WIRED_AGENTS=0
-  safe_ln "../../espalier/rules/engineering-structure.md" .claude/rules/espalier-structure.md && WIRED_RULES=$((WIRED_RULES+1))
-  safe_ln "../../espalier/rules/coding-standards.md"      .claude/rules/espalier-standards.md && WIRED_RULES=$((WIRED_RULES+1))
-  safe_ln "../../espalier/rules/development-process.md"   .claude/rules/espalier-process.md && WIRED_RULES=$((WIRED_RULES+1))
-  safe_ln "../../espalier/rules/security-standards.md"    .claude/rules/espalier-security.md && WIRED_RULES=$((WIRED_RULES+1))
-  safe_ln "../../espalier/rules/production-standards.md"  .claude/rules/espalier-production.md && WIRED_RULES=$((WIRED_RULES+1))
-  for s in espalier-coding espalier-review espalier-security espalier-testing espalier-requirements espalier-grill espalier espalier-fix espalier-prune espalier-doctor espalier-ask espalier-audit; do
-    safe_ln "../../espalier/skills/$s" ".claude/skills/$s" && WIRED_SKILLS=$((WIRED_SKILLS+1))
-  done
-  # Sub-agent identifiers intentionally kept as harness-coder / harness-reviewer
-  # (see SKILL.md Phase 0 note).
-  safe_ln "../../espalier/agents/harness-coder.md"    .claude/agents/harness-coder.md && WIRED_AGENTS=$((WIRED_AGENTS+1))
-  safe_ln "../../espalier/agents/harness-reviewer.md" .claude/agents/harness-reviewer.md && WIRED_AGENTS=$((WIRED_AGENTS+1))
-  safe_ln "../../espalier/agents/harness-security.md" .claude/agents/harness-security.md && WIRED_AGENTS=$((WIRED_AGENTS+1))
+  if want_claude; then
+    safe_ln "../../espalier/rules/engineering-structure.md" .claude/rules/espalier-structure.md && WIRED_RULES=$((WIRED_RULES+1))
+    safe_ln "../../espalier/rules/coding-standards.md"      .claude/rules/espalier-standards.md && WIRED_RULES=$((WIRED_RULES+1))
+    safe_ln "../../espalier/rules/development-process.md"   .claude/rules/espalier-process.md && WIRED_RULES=$((WIRED_RULES+1))
+    safe_ln "../../espalier/rules/security-standards.md"    .claude/rules/espalier-security.md && WIRED_RULES=$((WIRED_RULES+1))
+    safe_ln "../../espalier/rules/production-standards.md"  .claude/rules/espalier-production.md && WIRED_RULES=$((WIRED_RULES+1))
+    for s in $ESPALIER_SKILL_NAMES; do
+      safe_ln "../../espalier/skills/$s" ".claude/skills/$s" && WIRED_SKILLS=$((WIRED_SKILLS+1))
+    done
+    # Sub-agent identifiers intentionally kept as harness-coder / harness-reviewer
+    # (see SKILL.md Phase 0 note).
+    safe_ln "../../espalier/agents/harness-coder.md"    .claude/agents/harness-coder.md && WIRED_AGENTS=$((WIRED_AGENTS+1))
+    safe_ln "../../espalier/agents/harness-reviewer.md" .claude/agents/harness-reviewer.md && WIRED_AGENTS=$((WIRED_AGENTS+1))
+    safe_ln "../../espalier/agents/harness-security.md" .claude/agents/harness-security.md && WIRED_AGENTS=$((WIRED_AGENTS+1))
+  fi
+  if want_codex; then
+    # Codex discovers repo skills by probing .agents/skills/ (SkillScope::Repo).
+    # Same folder-name == frontmatter-name invariant as Claude Code, so the
+    # very same espalier/skills/<name> dirs wire straight in.
+    CODEX_SKILLS=0
+    for s in $ESPALIER_SKILL_NAMES; do
+      safe_ln "../../espalier/skills/$s" ".agents/skills/$s" && CODEX_SKILLS=$((CODEX_SKILLS+1))
+    done
+    log "  codex: $CODEX_SKILLS skills linked into .agents/skills/"
+    # Codex has no auto-loaded rules dir or agent .md registry; rules load via
+    # the AGENTS.md instruction (Stage 7b) and sub-agents via .codex/agents/*.toml
+    # (Stage 8c). Count them as wired only when claude didn't already.
+    if ! want_claude; then
+      WIRED_SKILLS=$CODEX_SKILLS
+      WIRED_RULES=5    # bound via the AGENTS.md always-read instruction
+      WIRED_AGENTS=3   # bound via .codex/agents/harness-*.toml
+    fi
+  fi
   # Read by espalier-init SKILL.md Phase 4 for the completion message — keep
   # this exact format.
   echo "WIRED: skills=$WIRED_SKILLS rules=$WIRED_RULES agents=$WIRED_AGENTS"
@@ -372,6 +465,10 @@ STATETMPL
 # --- Stage 7: CLAUDE.md append ----------------------------------------------
 
 stage_claudemd() {
+  if ! want_claude; then
+    log "Stage 7: CLAUDE.md append — skipped (claude not in --platforms)"
+    return
+  fi
   log "Stage 7: CLAUDE.md append (idempotent grep-guard)"
   if [ -f CLAUDE.md ] && grep -q "## Espalier" CLAUDE.md 2>/dev/null; then
     log "  CLAUDE.md already has Espalier section — skipping"
@@ -407,6 +504,10 @@ CLAUDETMPL
 # --- Stage 8: .claude/settings.json merge (Appendix A algorithm) ------------
 
 stage_settings_json() {
+  if ! want_claude; then
+    log "Stage 8: .claude/settings.json merge — skipped (claude not in --platforms)"
+    return
+  fi
   log "Stage 8: .claude/settings.json merge"
   if [ "$DRY_RUN" = "yes" ]; then
     echo "[dry-run] merge .claude/settings.json (Appendix A algorithm)"
@@ -505,12 +606,193 @@ except Exception as e:
 PYMERGE
 }
 
+# --- Stage 7b: AGENTS.md append (codex) --------------------------------------
+
+stage_agentsmd() {
+  if ! want_codex; then
+    return
+  fi
+  log "Stage 7b: AGENTS.md append (idempotent grep-guard)"
+  if [ -f AGENTS.md ] && grep -q "## Espalier" AGENTS.md 2>/dev/null; then
+    log "  AGENTS.md already has Espalier section — skipping"
+    return
+  fi
+  if [ "$DRY_RUN" = "yes" ]; then
+    echo "[dry-run] append Espalier section to AGENTS.md"
+    return
+  fi
+  cat >> AGENTS.md << 'AGENTSTMPL'
+
+## Espalier
+
+This project uses Espalier for AI code quality — auto-discovered, project-specific guardrails.
+
+**Always-loaded rules:** before writing or reviewing ANY code, read every file in
+`espalier/rules/` (engineering-structure, coding-standards, development-process,
+security-standards, production-standards). Codex has no auto-loaded rules
+directory — this instruction IS the load mechanism; do not skip it.
+
+**For any implementation work**, invoke the `espalier` skill (`$espalier <requirement>`) to execute the full pipeline.
+
+**For bug fixes**, invoke `$espalier-fix <bug>` for the slim lane — 7 stages (0–7, no Stage 2).
+
+**For questions** ("how does X work", "where is Y"), invoke `$espalier-ask <question>` — read-only, answers from espalier/ docs first.
+
+**For a repo-wide security audit**, invoke `$espalier-audit` — inventories trust-boundary defects in the existing code to `espalier/wiki/security-audit.md`; dispatch fixes via `$espalier-fix`.
+
+**Agent definition:** Read `espalier/agent.md` for your operating instructions.
+
+**Key principle:** The coder agent and reviewer agent are ALWAYS separate.
+Never review your own code in the same invocation that wrote it.
+
+### Platform mapping (Codex)
+
+Espalier's skill files use Claude Code vocabulary in places; on Codex apply these mappings:
+
+- `/espalier*` slash commands → `$espalier*` skill invocations.
+- `AskUserQuestion` → ask the user directly in chat and WAIT for the reply.
+  Where a skill says "if you can call AskUserQuestion you are interactive",
+  read it as: if you can ask the user in chat, you ARE interactive.
+- "Spawn sub-agent harness-coder / harness-reviewer / harness-security with
+  prompt X" → spawn the matching Codex subagent (defined in
+  `.codex/agents/<name>.toml`) with the same prompt. If subagent spawning is
+  unavailable in this session, execute the roles inline in strict sequence and
+  NEVER let the pass that wrote code also approve it: finish the coder role,
+  then re-read `espalier/agents/harness-reviewer.md` and review against the
+  actual diff as if you had not written it.
+- `.claude/settings.json` hooks → already wired in `.codex/config.toml`
+  (run `/hooks` once in Codex to trust them; they are the quality gates).
+- `$CLAUDE_PROJECT_DIR` in docs → the repo root (`git rev-parse --show-toplevel`).
+AGENTSTMPL
+}
+
+# --- Stage 8b: .codex/config.toml hooks merge (codex) ------------------------
+
+stage_codex_config() {
+  if ! want_codex; then
+    return
+  fi
+  log "Stage 8b: .codex/config.toml hooks merge (marker-guarded)"
+  if [ -f .codex/config.toml ] && grep -q "ESPALIER HOOKS" .codex/config.toml 2>/dev/null; then
+    log "  .codex/config.toml already has Espalier hook block — skipping"
+    return
+  fi
+  if [ "$DRY_RUN" = "yes" ]; then
+    echo "[dry-run] append Espalier hook block to .codex/config.toml"
+    return
+  fi
+  mkdir -p .codex
+  if [ -f .codex/config.toml ]; then
+    cp .codex/config.toml ".codex/config.toml.espalier-backup-$(date +%s)"
+    ls -t .codex/config.toml.espalier-backup-* 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null || true
+    # Appending [[hooks.*]] tables at EOF is always valid top-level TOML.
+    printf '\n' >> .codex/config.toml
+  fi
+  cat >> .codex/config.toml << 'CODEXHOOKS'
+# >>> ESPALIER HOOKS v1 >>> (managed by espalier bootstrap — do not edit between markers)
+# Same exit-code contract as Claude Code hooks: exit 2 + stderr blocks/feeds back.
+# Codex loads this project layer only when the project is trusted; run /hooks
+# once to trust these commands.
+[[hooks.PostToolUse]]
+matcher = "^(apply_patch|Edit|Write)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "bash espalier/hooks/post-edit-wrapper.sh"
+statusMessage = "Espalier layer-boundary check"
+timeout = 10
+
+[[hooks.PreToolUse]]
+matcher = "^(Bash|shell|local_shell)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "bash espalier/hooks/pre-push-gate-wrapper.sh"
+statusMessage = "Espalier push gate"
+timeout = 30
+# <<< ESPALIER HOOKS v1 <<<
+CODEXHOOKS
+  log "  .codex/config.toml: Espalier hook block appended"
+}
+
+# --- Stage 8c: .codex/agents/*.toml sub-agents (codex) ------------------------
+
+stage_codex_agents() {
+  if ! want_codex; then
+    return
+  fi
+  log "Stage 8c: .codex/agents/harness-*.toml (write-if-absent)"
+  if [ "$DRY_RUN" = "yes" ]; then
+    echo "[dry-run] write .codex/agents/harness-{coder,reviewer,security}.toml (if absent)"
+    return
+  fi
+  mkdir -p .codex/agents
+
+  # Write-if-absent ONLY — a user's later tuning (model, reasoning effort)
+  # survives re-bootstrap, same policy as espalier/.doctor-cadence.
+  if [ ! -f .codex/agents/harness-coder.toml ]; then
+    cat > .codex/agents/harness-coder.toml << 'CODERAGENT'
+# Espalier coder sub-agent (Codex). Instructions live in espalier/agents/harness-coder.md.
+name = "harness-coder"
+description = "Espalier implementation sub-agent — writes code strictly inside espalier/ rules; never reviews its own work"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+You are the harness-coder. Read espalier/agents/harness-coder.md and follow it
+exactly. Before writing any code, read every file in espalier/rules/ and the
+skill file espalier/skills/espalier-coding/SKILL.md. You implement; you never
+review or approve your own output.
+"""
+CODERAGENT
+    log "  wrote .codex/agents/harness-coder.toml"
+  else
+    log "  .codex/agents/harness-coder.toml exists — preserving"
+  fi
+
+  if [ ! -f .codex/agents/harness-reviewer.toml ]; then
+    cat > .codex/agents/harness-reviewer.toml << 'REVIEWERAGENT'
+# Espalier reviewer sub-agent (Codex). Instructions live in espalier/agents/harness-reviewer.md.
+name = "harness-reviewer"
+description = "Espalier review sub-agent — reviews diffs against espalier/ rules; writes ONLY its own review-record file"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+You are the harness-reviewer. Read espalier/agents/harness-reviewer.md and
+follow it exactly. Your ONLY permitted write is your own review record file
+(review-record.md in the active espalier/changes/ dir) — never source, tests,
+or any other file. Review the diff as written by someone else.
+"""
+REVIEWERAGENT
+    log "  wrote .codex/agents/harness-reviewer.toml"
+  else
+    log "  .codex/agents/harness-reviewer.toml exists — preserving"
+  fi
+
+  if [ ! -f .codex/agents/harness-security.toml ]; then
+    cat > .codex/agents/harness-security.toml << 'SECURITYAGENT'
+# Espalier security sub-agent (Codex). Instructions live in espalier/agents/harness-security.md.
+name = "harness-security"
+description = "Espalier security sub-agent — trust-boundary review against espalier/rules/security-standards.md; writes ONLY its own security-record file"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+You are the harness-security agent. Read espalier/agents/harness-security.md
+and follow it exactly. Your ONLY permitted write is your own security record
+file (security-record.md in the active espalier/changes/ dir, or
+espalier/wiki/security-audit.md in repo-audit mode) — never source, tests, or
+any other file.
+"""
+SECURITYAGENT
+    log "  wrote .codex/agents/harness-security.toml"
+  else
+    log "  .codex/agents/harness-security.toml exists — preserving"
+  fi
+}
+
 # --- Stage 9: Squash-merge decision + post-merge dispatcher -----------------
 
 stage_merge_decision() {
   log "Stage 9: persist Phase 0 decisions + post-merge dispatcher"
   if [ "$DRY_RUN" = "yes" ]; then
     echo "[dry-run] write espalier/.merge-hook-decision = $MERGE_DECISION"
+    echo "[dry-run] write espalier/.platforms = $PLATFORMS"
     echo "[dry-run] write espalier/.doctor-cadence = $DOCTOR_CADENCE (if absent)"
     echo "[dry-run] write espalier/.espalier-config = review-round caps (if absent)"
     echo "[dry-run] install post-merge dispatcher (drift-detect every merge; backlink if installed)"
@@ -518,6 +800,11 @@ stage_merge_decision() {
   fi
 
   echo "$MERGE_DECISION" > espalier/.merge-hook-decision
+
+  # espalier/.platforms — tracked; which agent platforms this repo is wired for.
+  # $PLATFORMS is already the union of the flag and any previous value (resolved
+  # at preflight), so a later "add codex" wire-only run extends, never shrinks.
+  echo "$PLATFORMS" > espalier/.platforms
 
   # espalier/.doctor-cadence — tracked, cadence-line only. Written ONCE; never
   # auto-rewritten, so a user's later edit to the cadence survives re-bootstrap.
@@ -703,9 +990,12 @@ stage_gitignore() {
 # --- Stage 11: Validation (parallel — R6) -----------------------------------
 
 stage_validate() {
-  log "Stage 11: validation (46 checks — R6)"
+  # Check count is platform-dependent: 46 base + 5 codex-wiring checks.
+  local TOTAL_CHECKS=46
+  want_codex && TOTAL_CHECKS=51
+  log "Stage 11: validation ($TOTAL_CHECKS checks — R6; platforms: $PLATFORMS)"
   if [ "$DRY_RUN" = "yes" ]; then
-    echo "[dry-run] would run 46 validation checks (skipped — nothing to validate yet)"
+    echo "[dry-run] would run $TOTAL_CHECKS validation checks (skipped — nothing to validate yet)"
     return 0
   fi
 
@@ -721,19 +1011,28 @@ stage_validate() {
     # like $name leaking into outer scope), (b) `exit` inside cmd killing
     # the run_check function.
     if ( eval "$cmd" ) >/dev/null 2>&1; then
-      echo "[$n/46] OK   $check_name" > "$tmpdir/$idx"
+      echo "[$n/$TOTAL_CHECKS] OK   $check_name" > "$tmpdir/$idx"
     else
       local err
       err=$( ( eval "$cmd" ) 2>&1 | head -1 )
-      echo "[$n/46] FAIL $check_name: $err" > "$tmpdir/$idx"
+      echo "[$n/$TOTAL_CHECKS] FAIL $check_name: $err" > "$tmpdir/$idx"
       echo "fail" > "$tmpdir/$idx.fail"
     fi
+  }
+
+  # For checks whose platform isn't targeted (e.g. .claude/ wiring on a
+  # codex-only install): report OK with a skip note, keep numbering stable.
+  skip_check() {
+    local n=$1 check_name=$2 why=$3
+    local idx
+    idx=$(printf '%02d' "$n")
+    echo "[$n/$TOTAL_CHECKS] OK   $check_name (skipped — $why)" > "$tmpdir/$idx"
   }
 
   # Check #25 — invoked DIRECTLY (not via run_check): the run_check harness
   # discards stdout, which would swallow #25's per-tier table.
   run_check_25() {
-    [ -f espalier/.drift-state.tsv ] || { echo "[25/46] OK   stale-tiers: no drift"; return 0; }
+    [ -f espalier/.drift-state.tsv ] || { echo "[25/$TOTAL_CHECKS] OK   stale-tiers: no drift"; return 0; }
     local NOW; NOW=$(date -u +%s)
     local fresh=0 aging=0 stale=0 critical=0 expired=0
     while IFS=$'\t' read -r FILE SHA FIRST_SEEN REASON; do
@@ -753,7 +1052,7 @@ stage_validate() {
       else expired=$((expired+1));                           echo "  [expired]  ${AGE}d  $FILE"
       fi
     done < espalier/.drift-state.tsv
-    echo "[25/46] stale-tiers: fresh=$fresh aging=$aging stale=$stale critical=$critical expired=$expired"
+    echo "[25/$TOTAL_CHECKS] stale-tiers: fresh=$fresh aging=$aging stale=$stale critical=$critical expired=$expired"
     [ "$critical" -gt 0 ] && echo "  WARN: $critical artifact(s) 60-90d stale"
     if [ "$expired" -gt 0 ]; then
       if [ "${IGNORE_DRIFT:-no}" = "yes" ]; then
@@ -770,20 +1069,37 @@ stage_validate() {
     return 0
   }
 
-  run_check  1 "rules-load"          'ls .claude/rules/espalier-*.md' &
-  run_check  2 "skills-load"         'ls -d .claude/skills/espalier-coding .claude/skills/espalier-review .claude/skills/espalier-security .claude/skills/espalier-testing .claude/skills/espalier-requirements .claude/skills/espalier-grill .claude/skills/espalier .claude/skills/espalier-fix .claude/skills/espalier-prune .claude/skills/espalier-doctor .claude/skills/espalier-ask .claude/skills/espalier-audit' &
-  run_check  3 "agents-load"         'ls .claude/agents/harness-coder.md .claude/agents/harness-reviewer.md .claude/agents/harness-security.md' &
-  run_check  4 "hooks-configured"    'grep -q "espalier/hooks" .claude/settings.json' &
-  run_check  5 "symlinks-valid"      '[ -L .claude/rules/espalier-structure.md ] && [ -e .claude/rules/espalier-structure.md ]' &
+  if want_claude; then
+    run_check  1 "rules-load"          'ls .claude/rules/espalier-*.md' &
+    run_check  2 "skills-load"         'ls -d .claude/skills/espalier-coding .claude/skills/espalier-review .claude/skills/espalier-security .claude/skills/espalier-testing .claude/skills/espalier-requirements .claude/skills/espalier-grill .claude/skills/espalier .claude/skills/espalier-fix .claude/skills/espalier-prune .claude/skills/espalier-doctor .claude/skills/espalier-ask .claude/skills/espalier-audit' &
+    run_check  3 "agents-load"         'ls .claude/agents/harness-coder.md .claude/agents/harness-reviewer.md .claude/agents/harness-security.md' &
+    run_check  4 "hooks-configured"    'grep -q "espalier/hooks" .claude/settings.json' &
+    run_check  5 "symlinks-valid"      '[ -L .claude/rules/espalier-structure.md ] && [ -e .claude/rules/espalier-structure.md ]' &
+  else
+    skip_check 1 "rules-load"       "claude not targeted"
+    skip_check 2 "skills-load"      "claude not targeted"
+    skip_check 3 "agents-load"      "claude not targeted"
+    skip_check 4 "hooks-configured" "claude not targeted"
+    skip_check 5 "symlinks-valid"   "claude not targeted"
+  fi
   run_check  6 "hooks-executable"    'test -x espalier/hooks/post-edit-wrapper.sh && test -x espalier/hooks/pre-push-gate.sh && test -x espalier/hooks/pre-push-gate-wrapper.sh' &
   run_check  7 "state-template"      'test -f espalier/changes/_template/pipeline-state.md' &
-  run_check  8 "claudemd-updated"    'grep -q "## Espalier" CLAUDE.md' &
+  if want_claude; then
+    run_check  8 "claudemd-updated"    'grep -q "## Espalier" CLAUDE.md' &
+  else
+    skip_check 8 "claudemd-updated" "claude not targeted"
+  fi
   run_check  9 "espalier-agent-md"   'test -f espalier/agent.md' &
   run_check 10 "espalier-pipeline-md" 'test -f espalier/pipeline.md' &
   run_check 11 "skill-name-parity"   'for f in espalier/skills/*/SKILL.md; do dir=$(basename $(dirname "$f")); name=$(grep "^name:" "$f" | awk "{print \$2}"); [ "$dir" = "$name" ] || exit 1; done' &
   run_check 12 "typed-changes-dirs"  '[ -d espalier/changes/feat ] && [ -d espalier/changes/fix ] && [ -d espalier/changes/refactor ]' &
-  run_check 13 "espalier-fix-skill"  'test -f .claude/skills/espalier-fix/SKILL.md' &
-  run_check 14 "espalier-fix-name"   'grep -q "^name: espalier-fix" .claude/skills/espalier-fix/SKILL.md' &
+  if want_claude; then
+    run_check 13 "espalier-fix-skill"  'test -f .claude/skills/espalier-fix/SKILL.md' &
+    run_check 14 "espalier-fix-name"   'grep -q "^name: espalier-fix" .claude/skills/espalier-fix/SKILL.md' &
+  else
+    run_check 13 "espalier-fix-skill"  'test -f espalier/skills/espalier-fix/SKILL.md' &
+    run_check 14 "espalier-fix-name"   'grep -q "^name: espalier-fix" espalier/skills/espalier-fix/SKILL.md' &
+  fi
   run_check 15 "rules-engineering"   'test -f espalier/rules/engineering-structure.md' &
   run_check 16 "rules-standards"     'test -f espalier/rules/coding-standards.md' &
   run_check 17 "merge-decision"      'grep -qE "^(not-needed|installed|fuzzy-allowed|skip-only|never-ask|ask-later)$" espalier/.merge-hook-decision' &
@@ -797,13 +1113,25 @@ stage_validate() {
   run_check 26 "drift-state-format"  '[ ! -s espalier/.drift-state.tsv ] || awk -F"\t" "NF != 4 { exit 1 }" espalier/.drift-state.tsv' &
   run_check 27 "conventions-format"  '[ ! -s espalier/.conventions.tsv ] || awk -F"\t" "NF != 5 && NF != 6 { exit 1 }" espalier/.conventions.tsv' &
   run_check 28 "doctor-cadence"      '[ ! -f espalier/.doctor-cadence ] || grep -qE "^cadence: (every-change|weekly|monthly|manual)$" espalier/.doctor-cadence' &
-  run_check 29 "espalier-ask-skill"  'test -f .claude/skills/espalier-ask/SKILL.md' &
-  run_check 30 "security-rule"       '[ -L .claude/rules/espalier-security.md ] && [ -e .claude/rules/espalier-security.md ]' &
-  run_check 31 "security-agent"      'test -f .claude/agents/harness-security.md' &
-  run_check 32 "security-skill"      'test -f .claude/skills/espalier-security/SKILL.md' &
-  run_check 33 "audit-skill"         'test -f .claude/skills/espalier-audit/SKILL.md' &
+  if want_claude; then
+    run_check 29 "espalier-ask-skill"  'test -f .claude/skills/espalier-ask/SKILL.md' &
+    run_check 30 "security-rule"       '[ -L .claude/rules/espalier-security.md ] && [ -e .claude/rules/espalier-security.md ]' &
+    run_check 31 "security-agent"      'test -f .claude/agents/harness-security.md' &
+    run_check 32 "security-skill"      'test -f .claude/skills/espalier-security/SKILL.md' &
+    run_check 33 "audit-skill"         'test -f .claude/skills/espalier-audit/SKILL.md' &
+  else
+    run_check 29 "espalier-ask-skill"  'test -f espalier/skills/espalier-ask/SKILL.md' &
+    run_check 30 "security-rule"       'test -f espalier/rules/security-standards.md' &
+    run_check 31 "security-agent"      'test -f espalier/agents/harness-security.md' &
+    run_check 32 "security-skill"      'test -f espalier/skills/espalier-security/SKILL.md' &
+    run_check 33 "audit-skill"         'test -f espalier/skills/espalier-audit/SKILL.md' &
+  fi
   run_check 34 "audit-mode"          'grep -qF "## Repo-Audit Mode" espalier/agents/harness-security.md' &
-  run_check 35 "production-rule"     '[ -L .claude/rules/espalier-production.md ] && [ -e .claude/rules/espalier-production.md ]' &
+  if want_claude; then
+    run_check 35 "production-rule"     '[ -L .claude/rules/espalier-production.md ] && [ -e .claude/rules/espalier-production.md ]' &
+  else
+    run_check 35 "production-rule"     'test -f espalier/rules/production-standards.md' &
+  fi
   run_check 36 "production-file"     'test -f espalier/rules/production-standards.md' &
   run_check 37 "scout-prompts"      'test -f espalier/.scout-prompts.md' &
   # 38-46: LLM-written artifacts (Phase 2) — existence checks with fix hints.
@@ -816,23 +1144,31 @@ stage_validate() {
   run_check 44 "wiki-external-services (fix: re-run espalier-init Phase 2)" 'test -f espalier/wiki/external-services.md' &
   run_check 45 "rules-development-process (fix: re-run espalier-init Phase 2)" 'test -f espalier/rules/development-process.md' &
   run_check 46 "layer-boundaries-hook (fix: Phase 2 writes it; --lang=unsupported writes a no-op)" 'test -f espalier/hooks/check-layer-boundaries.sh && test -x espalier/hooks/check-layer-boundaries.sh' &
+  # 47-51: codex wiring (only when codex is a target platform).
+  if want_codex; then
+    run_check 47 "codex-skills-load"   'ls -d .agents/skills/espalier-coding .agents/skills/espalier-review .agents/skills/espalier-security .agents/skills/espalier-testing .agents/skills/espalier-requirements .agents/skills/espalier-grill .agents/skills/espalier .agents/skills/espalier-fix .agents/skills/espalier-prune .agents/skills/espalier-doctor .agents/skills/espalier-ask .agents/skills/espalier-audit' &
+    run_check 48 "codex-symlinks-valid" '[ -L .agents/skills/espalier ] && [ -e .agents/skills/espalier ]' &
+    run_check 49 "codex-agents-toml"   'grep -q "^name = \"harness-coder\"" .codex/agents/harness-coder.toml && grep -q "^name = \"harness-reviewer\"" .codex/agents/harness-reviewer.toml && grep -q "^name = \"harness-security\"" .codex/agents/harness-security.toml' &
+    run_check 50 "codex-hooks-configured" 'grep -q "espalier/hooks" .codex/config.toml' &
+    run_check 51 "codex-agentsmd"      'grep -q "## Espalier" AGENTS.md' &
+  fi
 
   wait
 
   # Emit deterministic order: 1-24 (sorted), then #25 (serial — its tier table
-  # must reach stdout, which the run_check harness discards), then 26-46.
+  # must reach stdout, which the run_check harness discards), then 26-51.
   cat "$tmpdir"/0? "$tmpdir"/1? "$tmpdir"/2[0-4] 2>/dev/null
   run_check_25 || echo "fail" > "$tmpdir/25.fail"
-  cat "$tmpdir"/2[6-9] "$tmpdir"/3? "$tmpdir"/4[0-6] 2>/dev/null
+  cat "$tmpdir"/2[6-9] "$tmpdir"/3? "$tmpdir"/4[0-9] "$tmpdir"/5[0-1] 2>/dev/null
 
   failed=$(ls "$tmpdir"/*.fail 2>/dev/null | wc -l | tr -d ' ')
   rm -rf "$tmpdir"
 
   if [ "$failed" -gt 0 ]; then
-    log "Validation: $failed/46 FAILED"
+    log "Validation: $failed/$TOTAL_CHECKS FAILED"
     return 1
   fi
-  log "Validation: 46/46 passed"
+  log "Validation: $TOTAL_CHECKS/$TOTAL_CHECKS passed"
   return 0
 }
 
@@ -846,7 +1182,10 @@ case "$MODE" in
     stage_symlinks
     stage_state_template
     stage_claudemd
+    stage_agentsmd
     stage_settings_json
+    stage_codex_config
+    stage_codex_agents
     stage_merge_decision
     stage_gitignore
     stage_validate
@@ -858,10 +1197,14 @@ case "$MODE" in
     log "copy-only mode — stopping after Stage 4"
     ;;
   wire-only)
+    stage_mkdirs
     stage_symlinks
     stage_state_template
     stage_claudemd
+    stage_agentsmd
     stage_settings_json
+    stage_codex_config
+    stage_codex_agents
     stage_merge_decision
     stage_gitignore
     stage_validate

--- a/scripts/migrate-v0.13.2-to-v0.14.0.sh
+++ b/scripts/migrate-v0.13.2-to-v0.14.0.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Migrate a v0.13.2 Espalier install to v0.14.0.
+#
+# v0.14.0 adds Codex platform support. Two parts:
+#
+#   1. ALWAYS: refresh the two platform-neutral hook wrappers from the v0.14.0
+#      templates (pure copies, plugin-owned — never user-substituted):
+#        espalier/hooks/post-edit-wrapper.sh   — now also parses Codex
+#          apply_patch hook input ("*** Add|Update File:" lines, argv arrays)
+#          and resolves the repo root without $CLAUDE_PROJECT_DIR
+#        espalier/hooks/pre-push-gate-wrapper.sh — now joins argv-array
+#          commands (Codex shell tool) before the git-push pattern match
+#      Both changes are inert on Claude Code (same fields, same exit codes).
+#
+#   2. ONLY with --with-codex: wire the codex platform into this repo via
+#      bootstrap --wire-only --platforms=codex (unioned with the existing
+#      platform set — never unwires claude): .agents/skills/ symlinks,
+#      AGENTS.md section, .codex/config.toml hook block,
+#      .codex/agents/harness-*.toml sub-agents, checks 47-51.
+#      The /espalier-migrate skill asks the user; this script never prompts
+#      for it (pass the flag).
+#
+# Usage:
+#   bash migrate-v0.13.2-to-v0.14.0.sh [--dry-run] [--yes] [--with-codex] [--plugin-dir=<path>]
+
+set -u
+
+DRY_RUN=no
+SKIP_PROMPT=no
+WITH_CODEX=no
+PLUGIN_DIR="${ESPALIER_PLUGIN_DIR:-}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)      DRY_RUN=yes ;;
+    --yes)          SKIP_PROMPT=yes ;;
+    --with-codex)   WITH_CODEX=yes ;;
+    --plugin-dir=*) PLUGIN_DIR="${arg#--plugin-dir=}" ;;
+    -h|--help)      sed -n '2,24p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown flag: $arg (use --help)" >&2; exit 2 ;;
+  esac
+done
+
+log() { echo "[migrate v0.13.2→v0.14.0] $*"; }
+die() { echo "[migrate v0.13.2→v0.14.0] ERROR: $*" >&2; exit 1; }
+
+[ -d espalier ] || die "no espalier/ dir — run from the target project root."
+
+# --- Locate plugin templates -------------------------------------------------
+if [ -z "$PLUGIN_DIR" ]; then
+  _self_root="$(cd "$(dirname "$0")/.." && pwd)"
+  [ -d "$_self_root/skills/espalier-init/hook-templates" ] && PLUGIN_DIR="$_self_root"
+fi
+[ -n "$PLUGIN_DIR" ] || die "cannot locate the plugin. Pass --plugin-dir=<espalier-engineering root>."
+TPL="$PLUGIN_DIR/skills/espalier-init"
+POST_TPL="$TPL/hook-templates/post-edit-wrapper.sh"
+PUSH_TPL="$TPL/hook-templates/pre-push-gate-wrapper.sh"
+[ -f "$POST_TPL" ] || die "plugin dir $PLUGIN_DIR has no post-edit-wrapper template at $POST_TPL."
+[ -f "$PUSH_TPL" ] || die "plugin dir $PLUGIN_DIR has no pre-push-gate-wrapper template at $PUSH_TPL."
+
+# The templates must actually be v0.14.0 — otherwise a stale plugin would
+# "migrate" the wrappers straight back to Claude-only parsing.
+grep -qF 'apply_patch' "$POST_TPL" || \
+  die "template at $PLUGIN_DIR is not v0.14.0 (post-edit-wrapper lacks apply_patch parsing). Update the plugin first."
+grep -qF 'isinstance(c, list)' "$PUSH_TPL" || \
+  die "template at $PLUGIN_DIR is not v0.14.0 (pre-push-gate-wrapper lacks argv-array join). Update the plugin first."
+
+POST="espalier/hooks/post-edit-wrapper.sh"
+PUSH="espalier/hooks/pre-push-gate-wrapper.sh"
+
+# --- Idempotency --------------------------------------------------------------
+WRAPPERS_DONE=no
+if [ -f "$POST" ] && grep -qF 'apply_patch' "$POST" && \
+   [ -f "$PUSH" ] && grep -qF 'isinstance(c, list)' "$PUSH"; then
+  WRAPPERS_DONE=yes
+fi
+CODEX_DONE=no
+if grep -q codex espalier/.platforms 2>/dev/null; then
+  CODEX_DONE=yes
+fi
+
+if [ "$WRAPPERS_DONE" = yes ] && { [ "$WITH_CODEX" = no ] || [ "$CODEX_DONE" = yes ]; }; then
+  log "already at v0.14.0 (wrappers platform-neutral$( [ "$CODEX_DONE" = yes ] && echo '; codex wired' )). Nothing to do."
+  exit 0
+fi
+
+if [ "$DRY_RUN" = yes ]; then
+  log "DRY RUN — would:"
+  [ "$WRAPPERS_DONE" = no ] && {
+    log "  refresh $POST from the v0.14.0 template (backup .pre-v0.14.bak) — Codex apply_patch parsing"
+    log "  refresh $PUSH from the v0.14.0 template (backup .pre-v0.14.bak) — argv-array command join"
+  }
+  if [ "$WITH_CODEX" = yes ] && [ "$CODEX_DONE" = no ]; then
+    log "  wire the codex platform: bootstrap --wire-only --platforms=codex (additive)"
+  fi
+  exit 0
+fi
+
+if [ "$SKIP_PROMPT" != yes ]; then
+  printf "Apply the v0.14.0 migration (platform-neutral hook wrappers%s)? [y/N] " \
+    "$( [ "$WITH_CODEX" = yes ] && echo ' + codex wiring' )"
+  read -r reply
+  case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 0 ;; esac
+fi
+
+# --- Part 1: refresh the two wrappers (pure copy) -----------------------------
+if [ "$WRAPPERS_DONE" = no ]; then
+  for pair in "$POST_TPL:$POST" "$PUSH_TPL:$PUSH"; do
+    src="${pair%%:*}"; dst="${pair#*:}"
+    mkdir -p "$(dirname "$dst")"
+    if [ -f "$dst" ]; then
+      cp "$dst" "$dst.pre-v0.14.bak"
+      log "backed up -> $dst.pre-v0.14.bak"
+    fi
+    cp "$src" "$dst"
+    chmod +x "$dst"
+    log "refreshed $dst from the v0.14.0 template"
+  done
+else
+  log "wrappers already v0.14.0 — skipping refresh"
+fi
+
+# --- Part 2: codex wiring (only on request) -----------------------------------
+if [ "$WITH_CODEX" = yes ] && [ "$CODEX_DONE" = no ]; then
+  log "wiring codex platform (bootstrap --wire-only, additive)"
+  # --platforms=codex unions with the existing platform set (bootstrap infers
+  # "claude" for a complete pre-v0.14 install) — claude wiring is never lost.
+  bash "$PLUGIN_DIR/scripts/bootstrap-espalier.sh" \
+    --project-dir=. \
+    --plugin-dir="$TPL" \
+    --wire-only \
+    --platforms=codex \
+    --yes \
+    || die "codex wiring failed — see bootstrap output above ($POST.pre-v0.14.bak / $PUSH.pre-v0.14.bak hold the previous wrappers)"
+fi
+
+# --- Verification --------------------------------------------------------------
+pass=0; fail=0
+check() { if eval "$2" >/dev/null 2>&1; then pass=$((pass+1)); echo "  ✓ $1"; else fail=$((fail+1)); echo "  ✗ $1"; fi; }
+
+log "verification"
+check "post-edit-wrapper parses apply_patch input"   "grep -qF 'apply_patch' '$POST'"
+check "post-edit-wrapper resolves root without CLAUDE_PROJECT_DIR" "grep -qF 'git rev-parse --show-toplevel' '$POST'"
+check "pre-push-gate-wrapper joins argv arrays"      "grep -qF 'isinstance(c, list)' '$PUSH'"
+check "both wrappers executable"                     "test -x '$POST' && test -x '$PUSH'"
+if [ "$WITH_CODEX" = yes ]; then
+  check "espalier/.platforms includes codex"         "grep -q codex espalier/.platforms"
+  check ".agents/skills wired"                       "[ -L .agents/skills/espalier ]"
+  check ".codex/config.toml hook block present"      "grep -q 'espalier/hooks' .codex/config.toml"
+  check ".codex/agents sub-agents present"           "test -f .codex/agents/harness-coder.toml && test -f .codex/agents/harness-reviewer.toml && test -f .codex/agents/harness-security.toml"
+  check "AGENTS.md Espalier section present"         "grep -q '## Espalier' AGENTS.md"
+fi
+
+echo
+log "Verification: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || die "verification failed — previous wrappers are at $POST.pre-v0.14.bak / $PUSH.pre-v0.14.bak"
+log "v0.14.0 migration complete.$( [ "$WITH_CODEX" = yes ] && echo ' Codex: restart Codex, trust the project, run /hooks to trust the gates.' ) Backups: *.pre-v0.14.bak (delete when satisfied)."

--- a/scripts/migrate-v0.14.0-to-v0.15.0.sh
+++ b/scripts/migrate-v0.14.0-to-v0.15.0.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Migrate a v0.14.0 Espalier install to v0.15.0.
+#
+# v0.15.0 adds GitHub Copilot platform support. Two parts:
+#
+#   1. ALWAYS: copy the new plugin-owned Copilot hook shim into the install —
+#        espalier/hooks/copilot-hook-adapter.sh
+#      It translates Copilot's camelCase hook payload (toolName/toolArgs) into
+#      the Claude Code / Codex shape (tool_name/tool_input) and dispatches to
+#      the shared wrappers. Inert until Copilot hooks reference it.
+#
+#   2. ONLY with --with-copilot: wire the copilot platform into this repo via
+#      bootstrap --wire-only --platforms=copilot (unioned with the existing
+#      platform set — never unwires claude/codex): .github/skills/ symlinks,
+#      .github/copilot-instructions.md section, .github/agents/*.agent.md,
+#      .github/hooks/espalier-gates.json, checks 52-56.
+#      The /espalier-migrate skill asks the user; this script never prompts
+#      for it (pass the flag).
+#
+# Usage:
+#   bash migrate-v0.14.0-to-v0.15.0.sh [--dry-run] [--yes] [--with-copilot] [--plugin-dir=<path>]
+
+set -u
+
+DRY_RUN=no
+SKIP_PROMPT=no
+WITH_COPILOT=no
+PLUGIN_DIR="${ESPALIER_PLUGIN_DIR:-}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)       DRY_RUN=yes ;;
+    --yes)           SKIP_PROMPT=yes ;;
+    --with-copilot)  WITH_COPILOT=yes ;;
+    --plugin-dir=*)  PLUGIN_DIR="${arg#--plugin-dir=}" ;;
+    -h|--help)       sed -n '2,22p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown flag: $arg (use --help)" >&2; exit 2 ;;
+  esac
+done
+
+log() { echo "[migrate v0.14.0→v0.15.0] $*"; }
+die() { echo "[migrate v0.14.0→v0.15.0] ERROR: $*" >&2; exit 1; }
+
+[ -d espalier ] || die "no espalier/ dir — run from the target project root."
+
+# --- Locate plugin templates -------------------------------------------------
+if [ -z "$PLUGIN_DIR" ]; then
+  _self_root="$(cd "$(dirname "$0")/.." && pwd)"
+  [ -d "$_self_root/skills/espalier-init/hook-templates" ] && PLUGIN_DIR="$_self_root"
+fi
+[ -n "$PLUGIN_DIR" ] || die "cannot locate the plugin. Pass --plugin-dir=<espalier-engineering root>."
+TPL="$PLUGIN_DIR/skills/espalier-init"
+ADAPTER_TPL="$TPL/hook-templates/copilot-hook-adapter.sh"
+[ -f "$ADAPTER_TPL" ] || die "plugin dir $PLUGIN_DIR is not v0.15.0 (no copilot-hook-adapter template). Update the plugin first."
+
+ADAPTER="espalier/hooks/copilot-hook-adapter.sh"
+
+# --- Idempotency --------------------------------------------------------------
+ADAPTER_DONE=no
+[ -f "$ADAPTER" ] && ADAPTER_DONE=yes
+COPILOT_DONE=no
+grep -q copilot espalier/.platforms 2>/dev/null && COPILOT_DONE=yes
+
+if [ "$ADAPTER_DONE" = yes ] && { [ "$WITH_COPILOT" = no ] || [ "$COPILOT_DONE" = yes ]; }; then
+  log "already at v0.15.0 (adapter present$( [ "$COPILOT_DONE" = yes ] && echo '; copilot wired' )). Nothing to do."
+  exit 0
+fi
+
+if [ "$DRY_RUN" = yes ]; then
+  log "DRY RUN — would:"
+  [ "$ADAPTER_DONE" = no ] && log "  copy $ADAPTER from the v0.15.0 template (new file — Copilot camelCase hook shim)"
+  if [ "$WITH_COPILOT" = yes ] && [ "$COPILOT_DONE" = no ]; then
+    log "  wire the copilot platform: bootstrap --wire-only --platforms=copilot (additive)"
+  fi
+  exit 0
+fi
+
+if [ "$SKIP_PROMPT" != yes ]; then
+  printf "Apply the v0.15.0 migration (Copilot hook adapter%s)? [y/N] " \
+    "$( [ "$WITH_COPILOT" = yes ] && echo ' + copilot wiring' )"
+  read -r reply
+  case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 0 ;; esac
+fi
+
+# --- Part 1: install the adapter (new file — nothing to back up) --------------
+if [ "$ADAPTER_DONE" = no ]; then
+  mkdir -p espalier/hooks
+  cp "$ADAPTER_TPL" "$ADAPTER"
+  chmod +x "$ADAPTER"
+  log "installed $ADAPTER"
+else
+  log "adapter already present — skipping copy"
+fi
+
+# --- Part 2: copilot wiring (only on request) ----------------------------------
+if [ "$WITH_COPILOT" = yes ] && [ "$COPILOT_DONE" = no ]; then
+  log "wiring copilot platform (bootstrap --wire-only, additive)"
+  # --platforms=copilot unions with the existing platform set (bootstrap infers
+  # "claude" for a complete pre-v0.14 install) — nothing is ever unwired.
+  bash "$PLUGIN_DIR/scripts/bootstrap-espalier.sh" \
+    --project-dir=. \
+    --plugin-dir="$TPL" \
+    --wire-only \
+    --platforms=copilot \
+    --yes \
+    || die "copilot wiring failed — see bootstrap output above"
+fi
+
+# --- Verification --------------------------------------------------------------
+pass=0; fail=0
+check() { if eval "$2" >/dev/null 2>&1; then pass=$((pass+1)); echo "  ✓ $1"; else fail=$((fail+1)); echo "  ✗ $1"; fi; }
+
+log "verification"
+check "adapter present + executable"                "test -x '$ADAPTER'"
+check "adapter translates toolArgs"                 "grep -qF 'toolArgs' '$ADAPTER'"
+if [ "$WITH_COPILOT" = yes ]; then
+  check "espalier/.platforms includes copilot"      "grep -q copilot espalier/.platforms"
+  check ".github/skills wired"                      "[ -L .github/skills/espalier ]"
+  check ".github/hooks/espalier-gates.json present" "grep -q 'copilot-hook-adapter' .github/hooks/espalier-gates.json"
+  check ".github/agents custom agents present"      "test -f .github/agents/harness-coder.agent.md && test -f .github/agents/harness-reviewer.agent.md && test -f .github/agents/harness-security.agent.md"
+  check "copilot-instructions Espalier section"     "grep -q '## Espalier' .github/copilot-instructions.md"
+fi
+
+echo
+log "Verification: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || die "verification failed"
+log "v0.15.0 migration complete.$( [ "$WITH_COPILOT" = yes ] && echo ' Copilot: reload VS Code / restart Copilot CLI so skills register; gates run in CLI + cloud agent.' )"

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -361,6 +361,78 @@ assert "13c second run does not overwrite a modified hook" \
   "grep -q 'customised marker' '$TMP/espalier/hooks/check-layer-boundaries.sh'"
 [ "$KEEP" != "yes" ] && rm -rf "$TMP"
 
+# ─── Test 14: --platforms=claude,codex wires both platforms ───────────────
+echo "Test 14: --platforms=claude,codex"
+TMP=$(mktemp -d -t smoke14.XXXX)
+make_smoke_repo "$TMP"
+simulate_llm_writes "$TMP" typescript
+P_OUT=$( cd "$TMP" && bash "$BOOTSTRAP" --lang=typescript --merge-decision=ask-later --plugin-dir="$PLUGIN_DIR" --platforms=claude,codex --yes --force 2>&1 )
+P_EXIT=$?
+assert "14a exit 0"                          "[ $P_EXIT -eq 0 ]"
+assert "14b .agents/skills/espalier link"    "[ -L '$TMP/.agents/skills/espalier' ] && [ -e '$TMP/.agents/skills/espalier' ]"
+assert "14c .agents/skills/espalier-fix link" "[ -L '$TMP/.agents/skills/espalier-fix' ]"
+assert "14d .claude wiring still present"    "[ -L '$TMP/.claude/skills/espalier' ]"
+assert "14e AGENTS.md Espalier section"      "grep -q '## Espalier' '$TMP/AGENTS.md'"
+assert "14f AGENTS.md platform mapping"      "grep -q 'Platform mapping (Codex)' '$TMP/AGENTS.md'"
+assert "14g codex config hook block"         "grep -q 'espalier/hooks/post-edit-wrapper.sh' '$TMP/.codex/config.toml'"
+assert "14h codex config marker"             "grep -q 'ESPALIER HOOKS v1' '$TMP/.codex/config.toml'"
+assert "14i coder agent toml"                "grep -q '^name = \"harness-coder\"' '$TMP/.codex/agents/harness-coder.toml'"
+assert "14j reviewer agent toml"             "[ -f '$TMP/.codex/agents/harness-reviewer.toml' ]"
+assert "14k security agent toml"             "[ -f '$TMP/.codex/agents/harness-security.toml' ]"
+assert "14l platforms persisted"             "grep -qx 'claude,codex' '$TMP/espalier/.platforms'"
+assert "14m validation total is 51"          "echo \"\$P_OUT\" | grep -q 'Validation: 51/51 passed'"
+assert "14n codex checks ran"                "echo \"\$P_OUT\" | grep -qF '[47/51] OK'"
+assert "14o CLAUDE.md section still written" "grep -q '## Espalier' '$TMP/CLAUDE.md'"
+# TOML sanity: python tomllib parses the generated config + agent files.
+assert "14p config.toml parses"              "python3 -c 'import tomllib; tomllib.load(open(\"$TMP/.codex/config.toml\",\"rb\"))'"
+assert "14q agent toml parses"               "python3 -c 'import tomllib; tomllib.load(open(\"$TMP/.codex/agents/harness-coder.toml\",\"rb\"))'"
+# Idempotent re-run: no duplicate hook block, agent tomls preserved.
+echo "# user tuning marker" >> "$TMP/.codex/agents/harness-coder.toml"
+( cd "$TMP" && bash "$BOOTSTRAP" --wire-only --lang=typescript --plugin-dir="$PLUGIN_DIR" --platforms=claude,codex --yes >/dev/null 2>&1 )
+assert "14r re-run keeps ONE hook block"     "[ \$(grep -c '>>> ESPALIER HOOKS v1 >>>' '$TMP/.codex/config.toml') -eq 1 ]"
+assert "14s re-run preserves agent tuning"   "grep -q 'user tuning marker' '$TMP/.codex/agents/harness-coder.toml'"
+assert "14t re-run keeps ONE AGENTS.md section" "[ \$(grep -c '## Espalier' '$TMP/AGENTS.md') -eq 1 ]"
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
+# ─── Test 15: codex added to legacy claude install (additive union) ───────
+echo "Test 15: legacy install + --wire-only --platforms=codex"
+TMP=$(mktemp -d -t smoke15.XXXX)
+make_smoke_repo "$TMP"
+simulate_llm_writes "$TMP" typescript
+# Legacy claude-only install: full run WITHOUT --platforms, then delete
+# .platforms to simulate a pre-v0.14 install.
+( cd "$TMP" && bash "$BOOTSTRAP" --lang=typescript --merge-decision=ask-later --plugin-dir="$PLUGIN_DIR" --yes --force >/dev/null 2>&1 )
+rm -f "$TMP/espalier/.platforms"
+# Add codex later: wire-only, codex flag only, no --merge-decision (reused).
+W_OUT=$( cd "$TMP" && bash "$BOOTSTRAP" --wire-only --lang=typescript --plugin-dir="$PLUGIN_DIR" --platforms=codex --yes 2>&1 )
+W_EXIT=$?
+assert "15a wire-only exit 0"                "[ $W_EXIT -eq 0 ]"
+assert "15b merge decision reused"           "echo \"\$W_OUT\" | grep -q \"reusing persisted merge decision 'ask-later'\""
+assert "15c platforms unioned to claude,codex" "grep -qx 'claude,codex' '$TMP/espalier/.platforms'"
+assert "15d codex wired"                     "[ -L '$TMP/.agents/skills/espalier' ] && grep -q 'ESPALIER HOOKS' '$TMP/.codex/config.toml'"
+assert "15e claude wiring untouched"         "[ -L '$TMP/.claude/skills/espalier' ] && grep -q 'espalier/hooks' '$TMP/.claude/settings.json'"
+assert "15f validation total is 51"          "echo \"\$W_OUT\" | grep -q 'Validation: 51/51 passed'"
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
+# ─── Test 16: codex-only install (no .claude litter, claude checks skip) ──
+echo "Test 16: --platforms=codex only"
+TMP=$(mktemp -d -t smoke16.XXXX)
+make_smoke_repo "$TMP"
+simulate_llm_writes "$TMP" typescript
+# simulate_llm_writes' --copy-only helper ran with the claude default and made
+# empty .claude/ dirs — remove them so we can assert codex-only recreates none.
+rm -rf "$TMP/.claude"
+C_OUT=$( cd "$TMP" && bash "$BOOTSTRAP" --lang=typescript --merge-decision=ask-later --plugin-dir="$PLUGIN_DIR" --platforms=codex --yes --force 2>&1 )
+C_EXIT=$?
+assert "16a exit 0"                          "[ $C_EXIT -eq 0 ]"
+assert "16b no .claude dir created"          "[ ! -d '$TMP/.claude' ]"
+assert "16c no CLAUDE.md section"            "! grep -q '## Espalier' '$TMP/CLAUDE.md' 2>/dev/null"
+assert "16d codex fully wired"               "[ -L '$TMP/.agents/skills/espalier' ] && [ -f '$TMP/.codex/agents/harness-coder.toml' ] && grep -q '## Espalier' '$TMP/AGENTS.md'"
+assert "16e claude checks skipped OK"        "echo \"\$C_OUT\" | grep -qF 'OK   rules-load (skipped — claude not targeted)'"
+assert "16f validation passes"               "echo \"\$C_OUT\" | grep -q 'Validation: 51/51 passed'"
+assert "16g platforms = codex"               "grep -qx 'codex' '$TMP/espalier/.platforms'"
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
 # ─── Summary ──────────────────────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════"

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -433,6 +433,48 @@ assert "16f validation passes"               "echo \"\$C_OUT\" | grep -q 'Valida
 assert "16g platforms = codex"               "grep -qx 'codex' '$TMP/espalier/.platforms'"
 [ "$KEEP" != "yes" ] && rm -rf "$TMP"
 
+# ─── Test 17: --platforms=all wires claude+codex+copilot ──────────────────
+echo "Test 17: --platforms=all (three platforms)"
+TMP=$(mktemp -d -t smoke17.XXXX)
+make_smoke_repo "$TMP"
+simulate_llm_writes "$TMP" typescript
+A_OUT=$( cd "$TMP" && bash "$BOOTSTRAP" --lang=typescript --merge-decision=ask-later --plugin-dir="$PLUGIN_DIR" --platforms=all --yes --force 2>&1 )
+A_EXIT=$?
+assert "17a exit 0"                            "[ $A_EXIT -eq 0 ]"
+assert "17b platforms normalized+persisted"    "grep -qx 'claude,codex,copilot' '$TMP/espalier/.platforms'"
+assert "17c .github/skills/espalier link"      "[ -L '$TMP/.github/skills/espalier' ] && [ -e '$TMP/.github/skills/espalier' ]"
+assert "17d copilot agents written"            "grep -q '^name: harness-coder' '$TMP/.github/agents/harness-coder.agent.md' && [ -f '$TMP/.github/agents/harness-reviewer.agent.md' ] && [ -f '$TMP/.github/agents/harness-security.agent.md' ]"
+assert "17e hooks json valid + adapter wired"  "python3 -c 'import json; json.load(open(\"$TMP/.github/hooks/espalier-gates.json\"))' && grep -q 'copilot-hook-adapter' '$TMP/.github/hooks/espalier-gates.json'"
+assert "17f adapter copied + executable"       "[ -x '$TMP/espalier/hooks/copilot-hook-adapter.sh' ]"
+assert "17g copilot-instructions section"      "grep -q '## Espalier' '$TMP/.github/copilot-instructions.md'"
+assert "17h claude + codex wiring intact"      "[ -L '$TMP/.claude/skills/espalier' ] && [ -L '$TMP/.agents/skills/espalier' ]"
+assert "17i validation total is 56"            "echo \"\$A_OUT\" | grep -q 'Validation: 56/56 passed'"
+assert "17j copilot checks ran"                "echo \"\$A_OUT\" | grep -qF '[52/56] OK'"
+# Idempotent re-run: sections/files not duplicated, user tuning preserved.
+echo "<!-- user tuning marker -->" >> "$TMP/.github/agents/harness-coder.agent.md"
+( cd "$TMP" && bash "$BOOTSTRAP" --wire-only --lang=typescript --plugin-dir="$PLUGIN_DIR" --platforms=all --yes >/dev/null 2>&1 )
+assert "17k re-run keeps ONE instructions section" "[ \$(grep -c '^## Espalier' '$TMP/.github/copilot-instructions.md') -eq 1 ]"
+assert "17l re-run preserves agent tuning"     "grep -q 'user tuning marker' '$TMP/.github/agents/harness-coder.agent.md'"
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
+# ─── Test 18: copilot-only (no .claude litter, claude+codex checks skip) ──
+echo "Test 18: --platforms=copilot only"
+TMP=$(mktemp -d -t smoke18.XXXX)
+make_smoke_repo "$TMP"
+simulate_llm_writes "$TMP" typescript
+rm -rf "$TMP/.claude"
+P_OUT=$( cd "$TMP" && bash "$BOOTSTRAP" --lang=typescript --merge-decision=ask-later --plugin-dir="$PLUGIN_DIR" --platforms=copilot --yes --force 2>&1 )
+P_EXIT=$?
+assert "18a exit 0"                          "[ $P_EXIT -eq 0 ]"
+assert "18b no .claude dir created"          "[ ! -d '$TMP/.claude' ]"
+assert "18c no AGENTS.md written"            "[ ! -f '$TMP/AGENTS.md' ]"
+assert "18d copilot fully wired"             "[ -L '$TMP/.github/skills/espalier' ] && [ -f '$TMP/.github/agents/harness-coder.agent.md' ] && grep -q '## Espalier' '$TMP/.github/copilot-instructions.md'"
+assert "18e claude checks skipped OK"        "echo \"\$P_OUT\" | grep -qF 'OK   rules-load (skipped — claude not targeted)'"
+assert "18f codex checks skipped OK"         "echo \"\$P_OUT\" | grep -qF 'OK   codex-skills-load (skipped — codex not targeted)'"
+assert "18g validation total is 56"          "echo \"\$P_OUT\" | grep -q 'Validation: 56/56 passed'"
+assert "18h platforms = copilot"             "grep -qx 'copilot' '$TMP/espalier/.platforms'"
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
 # ─── Summary ──────────────────────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -545,6 +545,67 @@ assert "T9g2 checked path is absolute repo-rooted" "grep -q 'CHECKED:/.*src/bad.
 
 [ "$KEEP" != "yes" ] && rm -rf "$TMP"
 
+# ─── T10: copilot-hook-adapter.sh payload translation ─────────────────────
+echo "T10: copilot-hook-adapter"
+ADAPTER="$HOOKS_SRC/copilot-hook-adapter.sh"
+TMP=$(mktemp -d -t hooks-t10.XXXX)
+make_repo "$TMP"
+mkdir -p "$TMP/espalier/hooks" "$TMP/src"
+cp "$ADAPTER" "$TMP/espalier/hooks/copilot-hook-adapter.sh"
+cp "$HOOKS_SRC/pre-push-gate-wrapper.sh" "$TMP/espalier/hooks/pre-push-gate-wrapper.sh"
+cp "$HOOKS_SRC/post-edit-wrapper.sh" "$TMP/espalier/hooks/post-edit-wrapper.sh"
+chmod +x "$TMP/espalier/hooks/"*.sh
+printf '#!/bin/bash\necho GATE_RAN >&2\nexit 2\n' > "$TMP/espalier/hooks/pre-push-gate.sh"
+cat > "$TMP/espalier/hooks/check-layer-boundaries.sh" << 'STUB2'
+#!/bin/bash
+echo "CHECKED:$1" >&2
+case "$1" in *bad*) exit 2 ;; esac
+exit 0
+STUB2
+chmod +x "$TMP/espalier/hooks/pre-push-gate.sh" "$TMP/espalier/hooks/check-layer-boundaries.sh"
+touch "$TMP/src/ok.ts" "$TMP/src/bad.ts"
+
+# run_adapter_case NAME WRAPPER JSON EXPECT_RC EXPECT_MARK("-" = none)
+run_adapter_case() {
+  local name=$1 wrapper=$2 json=$3 expect_rc=$4 expect_mark=$5
+  local rc err="$TMP/a_err.txt"
+  ( cd "$TMP" && printf '%s' "$json" | env -u CLAUDE_PROJECT_DIR bash espalier/hooks/copilot-hook-adapter.sh "$wrapper" >/dev/null 2>"$err" )
+  rc=$?
+  assert "$name (rc)" "[ $rc -eq $expect_rc ]"
+  if [ "$expect_mark" = "-" ]; then
+    assert "$name (no dispatch)" "! grep -qE 'GATE_RAN|CHECKED:' '$err'"
+  else
+    assert "$name (marker)" "grep -q '$expect_mark' '$err'"
+  fi
+}
+
+run_adapter_case "T10a copilot bash push payload dispatches gate" \
+  pre-push-gate-wrapper.sh '{"toolName":"bash","toolArgs":{"command":"git push origin main"}}' 2 GATE_RAN
+run_adapter_case "T10b copilot bash non-push exits 0" \
+  pre-push-gate-wrapper.sh '{"toolName":"bash","toolArgs":{"command":"git status"}}' 0 -
+run_adapter_case "T10c copilot edit payload (path field) checks file" \
+  post-edit-wrapper.sh "{\"toolName\":\"edit\",\"toolArgs\":{\"path\":\"$TMP/src/bad.ts\"}}" 2 "CHECKED:.*src/bad.ts"
+run_adapter_case "T10d copilot edit payload (filePath variant) clean file" \
+  post-edit-wrapper.sh "{\"toolName\":\"str_replace_editor\",\"toolArgs\":{\"filePath\":\"$TMP/src/ok.ts\"}}" 0 "CHECKED:.*src/ok.ts"
+run_adapter_case "T10e garbage payload passes through harmlessly" \
+  post-edit-wrapper.sh 'not json at all' 0 -
+# T10f: missing wrapper → exit 0, never bricks the session.
+( cd "$TMP" && printf '%s' '{"toolName":"bash","toolArgs":{"command":"git push"}}' | bash espalier/hooks/copilot-hook-adapter.sh no-such-wrapper.sh >/dev/null 2>&1 )
+assert "T10f missing wrapper exits 0" "[ $? -eq 0 ]"
+# T10g: no python on PATH → raw passthrough; push-gate wrapper still fails CLOSED.
+PBIN10="$TMP/nopython-bin"
+mkdir -p "$PBIN10"
+for _t in bash sh cat grep sed git dirname; do
+  _p=$(command -v "$_t" 2>/dev/null) && [ -x "$_p" ] && ln -s "$_p" "$PBIN10/$_t"
+done
+( cd "$TMP" && printf '%s' '{"toolName":"bash","toolArgs":{"command":"git push"}}' \
+    | env -u CLAUDE_PROJECT_DIR PATH="$PBIN10" "$PBIN10/bash" espalier/hooks/copilot-hook-adapter.sh pre-push-gate-wrapper.sh >/dev/null 2>"$TMP/a_err.txt" )
+T10G_RC=$?
+assert "T10g no-python push still fails closed (exit 2)" "[ $T10G_RC -eq 2 ]"
+assert "T10g2 BLOCKED reason on stderr" "grep -q 'BLOCKED' '$TMP/a_err.txt'"
+
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
 # ─── Summary ──────────────────────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -482,6 +482,67 @@ T8F_RC=$?
 assert "T8f no python on PATH fails closed (exit 2)" "[ $T8F_RC -eq 2 ]"
 assert "T8f2 no-python block on stderr" "grep -q 'BLOCKED' '$TMP/w_err.txt'"
 
+run_wrapper_case "T8g codex argv-array push dispatches" \
+  '{"tool_input":{"command":["bash","-lc","git push origin main"]}}' 2 yes
+run_wrapper_case "T8h codex argv-array non-push exits 0" \
+  '{"tool_input":{"command":["bash","-lc","git status && ls"]}}' 0 no
+
+[ "$KEEP" != "yes" ] && rm -rf "$TMP"
+
+# ─── T9: post-edit-wrapper.sh payload matrix (Claude file_path + Codex apply_patch) ──
+echo "T9: post-edit-wrapper"
+PWRAP="$HOOKS_SRC/post-edit-wrapper.sh"
+TMP=$(mktemp -d -t hooks-t9.XXXX)
+make_repo "$TMP"
+mkdir -p "$TMP/espalier/hooks" "$TMP/src"
+# Boundary-check stub: exit 2 (violation) for any path containing "bad", else 0.
+# Echoes CHECKED:<path> to stderr so dispatch + path resolution are observable.
+cat > "$TMP/espalier/hooks/check-layer-boundaries.sh" << 'STUB'
+#!/bin/bash
+echo "CHECKED:$1" >&2
+case "$1" in *bad*) echo "violation in $1" >&2; exit 2 ;; esac
+exit 0
+STUB
+chmod +x "$TMP/espalier/hooks/check-layer-boundaries.sh"
+touch "$TMP/src/ok.ts" "$TMP/src/bad.ts" "$TMP/src/ok2.ts"
+
+# run_pwrap_case NAME JSON EXPECT_RC EXPECT_CHECKED_SUBSTR("-" = none)
+run_pwrap_case() {
+  local name=$1 json=$2 expect_rc=$3 expect_checked=$4
+  local rc err="$TMP/p_err.txt"
+  ( cd "$TMP" && printf '%s' "$json" | env -u CLAUDE_PROJECT_DIR bash "$PWRAP" >/dev/null 2>"$err" )
+  rc=$?
+  assert "$name (rc)" "[ $rc -eq $expect_rc ]"
+  if [ "$expect_checked" = "-" ]; then
+    assert "$name (no check ran)" "! grep -q 'CHECKED:' '$err'"
+  else
+    assert "$name (checked $expect_checked)" "grep -q 'CHECKED:.*$expect_checked' '$err'"
+  fi
+}
+
+run_pwrap_case "T9a claude file_path clean file" \
+  "{\"tool_input\":{\"file_path\":\"$TMP/src/ok.ts\"}}" 0 "src/ok.ts"
+run_pwrap_case "T9b claude file_path violating file" \
+  "{\"tool_input\":{\"file_path\":\"$TMP/src/bad.ts\"}}" 2 "src/bad.ts"
+CODEX_PATCH='{"tool_input":{"command":"*** Begin Patch\n*** Update File: src/ok.ts\n@@\n-a\n+b\n*** Add File: src/ok2.ts\n+x\n*** End Patch"}}'
+run_pwrap_case "T9c codex apply_patch multi-file (both clean)" \
+  "$CODEX_PATCH" 0 "src/ok2.ts"
+CODEX_BAD='{"tool_input":{"command":"*** Begin Patch\n*** Update File: src/ok.ts\n@@\n-a\n+b\n*** Update File: src/bad.ts\n@@\n-a\n+b\n*** End Patch"}}'
+run_pwrap_case "T9d codex apply_patch one violation → exit 2" \
+  "$CODEX_BAD" 2 "src/bad.ts"
+run_pwrap_case "T9e codex deleted-file patch line ignored" \
+  '{"tool_input":{"command":"*** Begin Patch\n*** Delete File: src/ok.ts\n*** End Patch"}}' 0 "-"
+run_pwrap_case "T9f empty/unknown tool_input exits 0" \
+  '{"tool_input":{"description":"noop"}}' 0 "-"
+# T9g: relative path from patch resolves against the git root even from a subdir.
+mkdir -p "$TMP/deep/nest"
+( cd "$TMP/deep/nest" && printf '%s' "$CODEX_BAD" | env -u CLAUDE_PROJECT_DIR bash "$PWRAP" >/dev/null 2>"$TMP/p_err.txt" )
+T9G_RC=$?
+assert "T9g subdir cwd still resolves + blocks (rc 2)" "[ $T9G_RC -eq 2 ]"
+# Absolute-path assertion, not string-equal to $TMP: on macOS git returns the
+# /private/var realpath while mktemp reports /var — same dir, different spelling.
+assert "T9g2 checked path is absolute repo-rooted" "grep -q 'CHECKED:/.*src/bad.ts' '$TMP/p_err.txt'"
+
 [ "$KEEP" != "yes" ] && rm -rf "$TMP"
 
 # ─── Summary ──────────────────────────────────────────────────────────────

--- a/skills/espalier-init/SKILL.md
+++ b/skills/espalier-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: espalier-init
-description: Analyze any existing codebase, discover its patterns and best practices, and generate an Espalier structure (rules, skills, wiki, pipeline) so AI coders produce code matching that project's language and conventions. Wires into Claude Code and/or Codex (.claude/ or .agents/skills/ + .codex/).
+description: Analyze any existing codebase, discover its patterns and best practices, and generate an Espalier structure (rules, skills, wiki, pipeline) so AI coders produce code matching that project's language and conventions. Wires into Claude Code, Codex, and/or GitHub Copilot (.claude/, .agents/skills/ + .codex/, .github/).
 ---
 
 # Espalier Init
@@ -58,6 +58,11 @@ project-root/
 ├── .codex/                         # [codex platform]
 │   ├── config.toml                # PreToolUse/PostToolUse hook block (marker-guarded)
 │   └── agents/                    # harness-{coder,reviewer,security}.toml sub-agents
+├── .github/                        # [copilot platform]
+│   ├── skills/                    # symlinks to espalier/skills/* (Copilot Agent Skills — VS Code/CLI/cloud agent)
+│   ├── agents/                    # harness-*.agent.md custom agents (@harness-coder …)
+│   ├── hooks/espalier-gates.json  # preToolUse/postToolUse gates via copilot-hook-adapter.sh
+│   └── copilot-instructions.md    # Espalier section + platform mapping (bootstrap-appended)
 ├── AGENTS.md                       # [codex] Espalier section + platform mapping (bootstrap-appended)
 ├── CLAUDE.md                       # [claude] references espalier/agent.md
 ├── espalier/
@@ -194,24 +199,28 @@ A doctor scan is activity-gated — an idle repo never triggers one.
        Never automatic; runs only when you invoke /espalier-doctor.
 ```
 
-### Q4 — Agent platform(s)
+### Q4 — Agent platform(s) (multiSelect: true — any subset)
 
 ```
-Which agent platform(s) should Espalier wire into this repo?
+Which agent platform(s) should Espalier wire into this repo? (pick every one
+your team uses; PLATFORMS = the comma list of selections)
 
-  1. Claude Code (default)                 → PLATFORMS = claude
+  1. Claude Code (default)                 → claude
        .claude/{rules,skills,agents} symlinks + CLAUDE.md + settings.json hooks.
-  2. Codex                                 → PLATFORMS = codex
+  2. Codex                                 → codex
        .agents/skills/ symlinks + AGENTS.md section + .codex/config.toml hooks
        + .codex/agents/harness-*.toml sub-agents.
-  3. Both                                  → PLATFORMS = claude,codex
-       All of the above. Pick this for mixed teams.
+  3. GitHub Copilot                        → copilot
+       .github/skills/ symlinks + .github/copilot-instructions.md section
+       + .github/agents/harness-*.agent.md sub-agents
+       + .github/hooks/espalier-gates.json gates (CLI + cloud agent).
 ```
 
-Default intelligently: if the repo already has an `AGENTS.md` or a teammate's
-`.codex/` dir, recommend Both; if you are RUNNING inside Codex, recommend
-Codex (or Both). The espalier/ content is identical either way — only the
-wiring differs.
+Default intelligently: `AGENTS.md` or a `.codex/` dir present → suggest adding
+codex; `.github/copilot-instructions.md` or the repo living on github.com with
+Copilot reviews → suggest adding copilot; RUNNING inside Codex/Copilot →
+include that platform. The espalier/ content is identical regardless — only
+the wiring differs, and later additions are one `--wire-only` run.
 
 > Why agent identifiers stay `harness-coder` / `harness-reviewer`: these are internal sub-agent names baked into pipeline orchestration. Renaming them mid-pipeline would break any in-flight changes. The plugin name and slash commands rebranded to Espalier in v0.4.0; agent identifiers remain frozen.
 
@@ -222,7 +231,7 @@ Phase 2's Write batch reads the Q2 answer (AGENT_TOOLS) when emitting `espalier/
 - `restricted` → keep the `tools:` frontmatter line from the template verbatim
 - `inherit` → omit the `tools:` line entirely (Claude Code interprets missing `tools:` as "inherit from parent")
 
-Pass the Q1, Q3, and Q4 answers to `bootstrap-espalier.sh` in Phase 3 as literal flag values (`--merge-decision=<answer from Q1> --doctor-cadence=<answer from Q3> --platforms=<answer from Q4>`). The Q2 answer only affects Phase 2 LLM writes, no bootstrap flag needed (the `.codex/agents/*.toml` sub-agents bootstrap emits for the codex platform always carry their contractual restrictions in `developer_instructions` — Q2 only shapes the Claude `tools:` frontmatter).
+Pass the Q1, Q3, and Q4 answers to `bootstrap-espalier.sh` in Phase 3 as literal flag values (`--merge-decision=<answer from Q1> --doctor-cadence=<answer from Q3> --platforms=<answer from Q4>`). The Q2 answer only affects Phase 2 LLM writes, no bootstrap flag needed (the `.codex/agents/*.toml` and `.github/agents/*.agent.md` sub-agents bootstrap emits for the codex/copilot platforms always carry their contractual restrictions in their instruction bodies — Q2 only shapes the Claude `tools:` frontmatter).
 
 ---
 
@@ -319,7 +328,7 @@ bash "${CLAUDE_SKILL_DIR}/../../scripts/bootstrap-espalier.sh" \
   --lang=<LANG_CHOICE from Phase 1 discovery: typescript|python|go|unsupported> \
   --merge-decision=<answer from Q1> \
   --doctor-cadence=<answer from Q3> \
-  --platforms=<answer from Q4: claude|codex|claude,codex>
+  --platforms=<answer from Q4: comma list of claude|codex|copilot>
 ```
 
 Shell variables do NOT persist between Bash calls — substitute literal values
@@ -345,7 +354,7 @@ Bootstrap runs all 11 internal stages in one shell process:
 - **Stage 8:** merge `.claude/settings.json` hooks (additive by `(matcher, command)` tuple — never clobbers user hooks; atomic temp-file write + backup).
 - **Stage 9:** persist the merge decision (the literal Q1 answer passed via `--merge-decision`) to `espalier/.merge-hook-decision` and the Phase 0 Q3 cadence to `espalier/.doctor-cadence` (written once, never auto-rewritten). Install the post-merge dispatcher (`.husky/post-merge` or `.git/hooks/post-merge`) unconditionally — it runs `drift-detect.sh` on every merge and `post-merge-backlink.sh` only when the decision is `installed`.
 - **Stage 10:** append `espalier/.commit-index.tsv` + the drift sidecars (`.drift-state.tsv*`, `.drift.log`, `.drift-report.md`, `.doctor-last-run`, `.drift-overrides.log`) to `.gitignore` (newline-guarded).
-- **Stage 11:** run the validation checks — 46 when only claude is targeted, 51 with codex (all but #25 in parallel, #25 serial for its tier table); print sorted output; non-zero exit if any failed.
+- **Stage 11:** run the validation checks — 46 when only claude is targeted, 51 with codex, 56 with copilot (all but #25 in parallel, #25 serial for its tier table); print sorted output; non-zero exit if any failed.
 
 **Re-run safety:** if `espalier/.merge-hook-decision` exists, bootstrap auto-runs Stage 11 only (idempotent re-run = health check). `--force` overrides.
 
@@ -373,7 +382,7 @@ Either way — thanks for trying it.
 
 Fill `N`, `M`, `K` from the `WIRED: skills=<n> rules=<n> agents=<n>` line bootstrap Stage 5 printed. If the line is absent, drop that clause rather than guess.
 
-**If the codex platform was wired** (Q4 = codex or both), insert this block
+**If the codex platform was wired** (codex in Q4), insert this block
 IMMEDIATELY BEFORE the message above (verbatim, it is part of the final reply):
 
 ```
@@ -384,27 +393,38 @@ Codex wiring is in place. Three one-time steps inside Codex:
 Then invoke the pipeline with $espalier <requirement> ($espalier-fix, $espalier-ask, $espalier-audit likewise).
 ```
 
+**If the copilot platform was wired** (copilot in Q4), also insert:
+
+```
+Copilot wiring is in place. Notes:
+  - Reload VS Code (or restart Copilot CLI) so the Agent Skills register; invoke with /espalier <requirement>.
+  - The quality gates (.github/hooks/espalier-gates.json) run in Copilot CLI and the cloud coding agent; VS Code chat does not execute hooks — the pipeline's in-skill gates still apply there.
+  - Sub-agents are @harness-coder / @harness-reviewer / @harness-security (.github/agents/).
+```
+
 **Rule:** this is the ONLY end-of-install ask. No telemetry, no follow-up nag, no second prompt on re-runs — bootstrap's idempotent re-run path (`espalier/.merge-hook-decision` already present → validate-only) skips Phase 4 entirely.
 
 ---
 
-## Running under Codex (platform fallbacks)
+## Running under Codex or Copilot (platform fallbacks)
 
 This skill was written for Claude Code but runs under Codex (installed per the
 README: clone espalier-engineering, symlink `skills/espalier-init` into
-`~/.agents/skills/`, invoke `$espalier-init`). Every phase works — substitute
-these mechanics:
+`~/.agents/skills/`, invoke `$espalier-init`) or Copilot (symlink into
+`~/.copilot/skills/` — or rely on `~/.agents/skills/`, which VS Code also
+reads — invoke `/espalier-init`). Every phase works — substitute these
+mechanics:
 
 | Claude Code mechanic | Codex substitute |
 |---|---|
 | `AskUserQuestion` (Phase 0, no-evidence follow-ups) | Ask the same questions in chat, numbered, and WAIT for the reply. Never guess an answer to proceed. |
-| `scout` / `oracle` sub-agent calls (Phase 1/2) | Spawn Codex subagents with the same prompt text if subagent spawning is available; otherwise run each scout's instructions yourself, inline, one at a time (read the named files, produce the same JSON shape). Sequential is fine — correctness beats parallelism. |
+| `scout` / `oracle` sub-agent calls (Phase 1/2) | Spawn platform subagents (Codex subagents / Copilot custom agents) with the same prompt text if available; otherwise run each scout's instructions yourself, inline, one at a time (read the named files, produce the same JSON shape). Sequential is fine — correctness beats parallelism. |
 | `${CLAUDE_SKILL_DIR}` (Phase 3) | The absolute directory of this SKILL.md, physically resolved (`pwd -P`) so the `../../scripts/` hop works through the install symlink. |
 | `AskUserQuestion` availability as the interactivity test | "Can I ask the user in chat" is the same test. |
 
 Phase 2's Write batch and Phase 3's bootstrap are already platform-neutral
-(plain file writes + one bash script). Pick `codex` (or `claude,codex`) at
-Q4 — you are the proof the user runs Codex.
+(plain file writes + one bash script). Include the platform you are running
+on in the Q4 answer — you are the proof the user uses it.
 
 ---
 

--- a/skills/espalier-init/SKILL.md
+++ b/skills/espalier-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: espalier-init
-description: Analyze any existing codebase, discover its patterns and best practices, and generate an Espalier structure (rules, skills, wiki, pipeline) so AI coders produce code matching that project's language and conventions
+description: Analyze any existing codebase, discover its patterns and best practices, and generate an Espalier structure (rules, skills, wiki, pipeline) so AI coders produce code matching that project's language and conventions. Wires into Claude Code and/or Codex (.claude/ or .agents/skills/ + .codex/).
 ---
 
 # Espalier Init
@@ -48,12 +48,18 @@ espalier-init/
 
 ```
 project-root/
-├── .claude/
+├── .claude/                        # [claude platform]
 │   ├── rules/                     # symlinks to espalier/rules/*.md
 │   ├── skills/                    # symlinks to espalier/skills/*
 │   ├── agents/                    # symlinks to espalier/agents/*.md
 │   └── settings.json              # hooks for quality gates
-├── CLAUDE.md                       # references espalier/agent.md
+├── .agents/                        # [codex platform]
+│   └── skills/                    # symlinks to espalier/skills/* (Codex repo-skill discovery)
+├── .codex/                         # [codex platform]
+│   ├── config.toml                # PreToolUse/PostToolUse hook block (marker-guarded)
+│   └── agents/                    # harness-{coder,reviewer,security}.toml sub-agents
+├── AGENTS.md                       # [codex] Espalier section + platform mapping (bootstrap-appended)
+├── CLAUDE.md                       # [claude] references espalier/agent.md
 ├── espalier/
 │   ├── agent.md                    # orchestrator definition
 │   ├── rules/                      # engineering-structure, coding-standards, development-process, security-standards, production-standards
@@ -122,7 +128,9 @@ Phases 0-2 are sequential by necessity (Phase 0 prompt blocks; Phase 1 produces 
 
 ## Phase 0: Setup Decisions (front-loaded)
 
-Issue ONE `AskUserQuestion` with THREE questions in the multi-question form:
+Issue ONE `AskUserQuestion` with FOUR questions in the multi-question form
+(under Codex there is no AskUserQuestion tool — ask the same questions in chat
+and wait for answers; see "Running under Codex" below):
 
 ### Q1 — Squash-merge strategy
 
@@ -186,6 +194,25 @@ A doctor scan is activity-gated — an idle repo never triggers one.
        Never automatic; runs only when you invoke /espalier-doctor.
 ```
 
+### Q4 — Agent platform(s)
+
+```
+Which agent platform(s) should Espalier wire into this repo?
+
+  1. Claude Code (default)                 → PLATFORMS = claude
+       .claude/{rules,skills,agents} symlinks + CLAUDE.md + settings.json hooks.
+  2. Codex                                 → PLATFORMS = codex
+       .agents/skills/ symlinks + AGENTS.md section + .codex/config.toml hooks
+       + .codex/agents/harness-*.toml sub-agents.
+  3. Both                                  → PLATFORMS = claude,codex
+       All of the above. Pick this for mixed teams.
+```
+
+Default intelligently: if the repo already has an `AGENTS.md` or a teammate's
+`.codex/` dir, recommend Both; if you are RUNNING inside Codex, recommend
+Codex (or Both). The espalier/ content is identical either way — only the
+wiring differs.
+
 > Why agent identifiers stay `harness-coder` / `harness-reviewer`: these are internal sub-agent names baked into pipeline orchestration. Renaming them mid-pipeline would break any in-flight changes. The plugin name and slash commands rebranded to Espalier in v0.4.0; agent identifiers remain frozen.
 
 Note the answers; you will substitute them literally in Phase 3 — shell
@@ -195,7 +222,7 @@ Phase 2's Write batch reads the Q2 answer (AGENT_TOOLS) when emitting `espalier/
 - `restricted` → keep the `tools:` frontmatter line from the template verbatim
 - `inherit` → omit the `tools:` line entirely (Claude Code interprets missing `tools:` as "inherit from parent")
 
-Pass the Q1 and Q3 answers to `bootstrap-espalier.sh` in Phase 3 as literal flag values (`--merge-decision=<answer from Q1> --doctor-cadence=<answer from Q3>`). The Q2 answer only affects Phase 2 LLM writes, no bootstrap flag needed.
+Pass the Q1, Q3, and Q4 answers to `bootstrap-espalier.sh` in Phase 3 as literal flag values (`--merge-decision=<answer from Q1> --doctor-cadence=<answer from Q3> --platforms=<answer from Q4>`). The Q2 answer only affects Phase 2 LLM writes, no bootstrap flag needed (the `.codex/agents/*.toml` sub-agents bootstrap emits for the codex platform always carry their contractual restrictions in `developer_instructions` — Q2 only shapes the Claude `tools:` frontmatter).
 
 ---
 
@@ -291,13 +318,21 @@ bash "${CLAUDE_SKILL_DIR}/../../scripts/bootstrap-espalier.sh" \
   --plugin-dir="${CLAUDE_SKILL_DIR}" \
   --lang=<LANG_CHOICE from Phase 1 discovery: typescript|python|go|unsupported> \
   --merge-decision=<answer from Q1> \
-  --doctor-cadence=<answer from Q3>
+  --doctor-cadence=<answer from Q3> \
+  --platforms=<answer from Q4: claude|codex|claude,codex>
 ```
 
 Shell variables do NOT persist between Bash calls — substitute literal values
 into this command before running (the `<...>` tokens are placeholders YOU fill
 verbatim, never live shell variables; `${CLAUDE_SKILL_DIR}` is the one
 exception — the harness sets it for the invocation itself).
+
+**Under Codex** `CLAUDE_SKILL_DIR` is NOT set: substitute the absolute
+directory of THIS SKILL.md (you know it — you were invoked with its path) for
+both `--plugin-dir=` and the script path. If the skill dir is a symlink into a
+clone of espalier-engineering (the documented Codex install), resolve it first
+so `../../scripts/` lands in the clone:
+`SKILL_DIR=$(cd <this skill dir> && pwd -P)`.
 
 Bootstrap runs all 11 internal stages in one shell process:
 
@@ -310,7 +345,7 @@ Bootstrap runs all 11 internal stages in one shell process:
 - **Stage 8:** merge `.claude/settings.json` hooks (additive by `(matcher, command)` tuple — never clobbers user hooks; atomic temp-file write + backup).
 - **Stage 9:** persist the merge decision (the literal Q1 answer passed via `--merge-decision`) to `espalier/.merge-hook-decision` and the Phase 0 Q3 cadence to `espalier/.doctor-cadence` (written once, never auto-rewritten). Install the post-merge dispatcher (`.husky/post-merge` or `.git/hooks/post-merge`) unconditionally — it runs `drift-detect.sh` on every merge and `post-merge-backlink.sh` only when the decision is `installed`.
 - **Stage 10:** append `espalier/.commit-index.tsv` + the drift sidecars (`.drift-state.tsv*`, `.drift.log`, `.drift-report.md`, `.doctor-last-run`, `.drift-overrides.log`) to `.gitignore` (newline-guarded).
-- **Stage 11:** run 46 validation checks (45 in parallel, #25 serial for its tier table); print sorted output; non-zero exit if any failed.
+- **Stage 11:** run the validation checks — 46 when only claude is targeted, 51 with codex (all but #25 in parallel, #25 serial for its tier table); print sorted output; non-zero exit if any failed.
 
 **Re-run safety:** if `espalier/.merge-hook-decision` exists, bootstrap auto-runs Stage 11 only (idempotent re-run = health check). `--force` overrides.
 
@@ -338,7 +373,38 @@ Either way — thanks for trying it.
 
 Fill `N`, `M`, `K` from the `WIRED: skills=<n> rules=<n> agents=<n>` line bootstrap Stage 5 printed. If the line is absent, drop that clause rather than guess.
 
+**If the codex platform was wired** (Q4 = codex or both), insert this block
+IMMEDIATELY BEFORE the message above (verbatim, it is part of the final reply):
+
+```
+Codex wiring is in place. Three one-time steps inside Codex:
+  1. Restart Codex in this repo (skills + config load at startup).
+  2. Trust the project when prompted (project .codex/ layers only load when trusted).
+  3. Run /hooks and trust the two Espalier hook commands (the quality gates).
+Then invoke the pipeline with $espalier <requirement> ($espalier-fix, $espalier-ask, $espalier-audit likewise).
+```
+
 **Rule:** this is the ONLY end-of-install ask. No telemetry, no follow-up nag, no second prompt on re-runs — bootstrap's idempotent re-run path (`espalier/.merge-hook-decision` already present → validate-only) skips Phase 4 entirely.
+
+---
+
+## Running under Codex (platform fallbacks)
+
+This skill was written for Claude Code but runs under Codex (installed per the
+README: clone espalier-engineering, symlink `skills/espalier-init` into
+`~/.agents/skills/`, invoke `$espalier-init`). Every phase works — substitute
+these mechanics:
+
+| Claude Code mechanic | Codex substitute |
+|---|---|
+| `AskUserQuestion` (Phase 0, no-evidence follow-ups) | Ask the same questions in chat, numbered, and WAIT for the reply. Never guess an answer to proceed. |
+| `scout` / `oracle` sub-agent calls (Phase 1/2) | Spawn Codex subagents with the same prompt text if subagent spawning is available; otherwise run each scout's instructions yourself, inline, one at a time (read the named files, produce the same JSON shape). Sequential is fine — correctness beats parallelism. |
+| `${CLAUDE_SKILL_DIR}` (Phase 3) | The absolute directory of this SKILL.md, physically resolved (`pwd -P`) so the `../../scripts/` hop works through the install symlink. |
+| `AskUserQuestion` availability as the interactivity test | "Can I ask the user in chat" is the same test. |
+
+Phase 2's Write batch and Phase 3's bootstrap are already platform-neutral
+(plain file writes + one bash script). Pick `codex` (or `claude,codex`) at
+Q4 — you are the proof the user runs Codex.
 
 ---
 

--- a/skills/espalier-init/hook-templates/copilot-hook-adapter.sh
+++ b/skills/espalier-init/hook-templates/copilot-hook-adapter.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copilot → espalier hook adapter.
+#
+# GitHub Copilot hooks (CLI + cloud agent, .github/hooks/*.json) send a
+# camelCase payload — {"toolName": "bash", "toolArgs": {...}} — while the two
+# shared espalier wrappers speak the Claude Code / Codex shape
+# ({"tool_name": ..., "tool_input": {...}}). This shim translates and
+# dispatches, so the SAME wrapper scripts serve all three platforms.
+#
+# Usage (from .github/hooks/espalier-gates.json):
+#   bash espalier/hooks/copilot-hook-adapter.sh pre-push-gate-wrapper.sh
+#   bash espalier/hooks/copilot-hook-adapter.sh post-edit-wrapper.sh
+#
+# Exit code passes through untouched. Copilot preToolUse treats exit 2 — and
+# any other non-timeout non-zero — as DENY (fail-closed), which matches the
+# wrappers' own blocking contract; postToolUse output is advisory feedback.
+
+WRAPPER_NAME="$1"
+DIR=$(cd "$(dirname "$0")" && pwd)
+WRAPPER="$DIR/$WRAPPER_NAME"
+[ -f "$WRAPPER" ] || exit 0   # espalier hooks not installed here — never brick the session
+
+INPUT=$(cat)
+
+PYBIN=""
+command -v python3 >/dev/null 2>&1 && PYBIN=python3
+[ -z "$PYBIN" ] && command -v python >/dev/null 2>&1 && PYBIN=python
+
+if [ -z "$PYBIN" ]; then
+  # No python: pass the RAW payload through. The push-gate wrapper's fast path
+  # greps the whole JSON for git+push tokens (camelCase or not), and its own
+  # python probe then fails closed only for a suspected push; the post-edit
+  # wrapper exits 0 without python (advisory). No translation needed to keep
+  # both contracts intact.
+  printf '%s' "$INPUT" | bash "$WRAPPER"
+  exit $?
+fi
+
+TRANSLATED=$(printf '%s' "$INPUT" | "$PYBIN" -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+args = d.get('toolArgs') or d.get('tool_input') or {}
+if isinstance(args, dict):
+    # Normalise the edited-file field name variants to file_path.
+    if 'file_path' not in args:
+        for k in ('path', 'file', 'filePath', 'fileName'):
+            if args.get(k):
+                args['file_path'] = args[k]
+                break
+out = {'tool_name': d.get('toolName') or d.get('tool_name') or '', 'tool_input': args}
+print(json.dumps(out))
+" 2>/dev/null)
+
+if [ -z "$TRANSLATED" ]; then
+  # Unparseable payload: same rationale as the no-python branch — hand the raw
+  # bytes to the wrapper and let its own fail-open/fail-closed logic decide.
+  printf '%s' "$INPUT" | bash "$WRAPPER"
+  exit $?
+fi
+
+printf '%s' "$TRANSLATED" | bash "$WRAPPER"
+exit $?

--- a/skills/espalier-init/hook-templates/post-edit-wrapper.sh
+++ b/skills/espalier-init/hook-templates/post-edit-wrapper.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-# Reads hook input JSON from stdin, extracts file_path, runs boundary check
+# Reads hook input JSON from stdin, extracts the edited file path(s), runs the
+# layer-boundary check on each.
+#
+# Platform-neutral (Claude Code + Codex — both emit the same hook JSON shape):
+#   - Claude Code Write|Edit  → tool_input.file_path (single path)
+#   - Codex apply_patch       → tool_input.command (or .input) holds the patch
+#     body; changed paths appear as "*** Add File:" / "*** Update File:" lines
 INPUT=$(cat)
 
 # PYBIN probe: prefer python3, fall back to python. Post-edit is advisory (not
@@ -9,9 +15,43 @@ command -v python3 >/dev/null 2>&1 && PYBIN=python3
 [ -z "$PYBIN" ] && command -v python >/dev/null 2>&1 && PYBIN=python
 [ -z "$PYBIN" ] && exit 0
 
-FILE_PATH=$(echo "$INPUT" | "$PYBIN" -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null)
+FILE_PATHS=$(printf '%s' "$INPUT" | "$PYBIN" -c "
+import sys, json, re
+try:
+    ti = json.load(sys.stdin).get('tool_input', {}) or {}
+except Exception:
+    sys.exit(0)
+fp = ti.get('file_path', '')
+if fp:
+    print(fp)
+else:
+    patch = ti.get('command') or ti.get('input') or ''
+    if isinstance(patch, list):
+        patch = ' '.join(str(x) for x in patch)
+    for m in re.findall(r'^\*\*\* (?:Add|Update) File: (.+)$', str(patch), re.M):
+        print(m.strip())
+" 2>/dev/null)
 
-if [ -n "$FILE_PATH" ] && [ -f "$FILE_PATH" ]; then
-  exec bash "$CLAUDE_PROJECT_DIR/espalier/hooks/check-layer-boundaries.sh" "$FILE_PATH"
-fi
-exit 0
+[ -z "$FILE_PATHS" ] && exit 0
+
+# Hook subprocess cwd is not guaranteed to be the repo root on either platform.
+# Claude Code sets CLAUDE_PROJECT_DIR; Codex does not — fall back to git.
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[ -z "$ROOT" ] && exit 0
+[ -f "$ROOT/espalier/hooks/check-layer-boundaries.sh" ] || exit 0
+
+# Check every edited file; exit 2 if ANY violates (each check writes its own
+# reason to stderr — PostToolUse feedback semantics, same on both platforms).
+RC=0
+while IFS= read -r FILE_PATH; do
+  [ -z "$FILE_PATH" ] && continue
+  case "$FILE_PATH" in
+    /*) ABS="$FILE_PATH" ;;
+    *)  ABS="$ROOT/$FILE_PATH" ;;
+  esac
+  [ -f "$ABS" ] || continue
+  bash "$ROOT/espalier/hooks/check-layer-boundaries.sh" "$ABS" || RC=2
+done << EOF
+$FILE_PATHS
+EOF
+exit $RC

--- a/skills/espalier-init/hook-templates/pre-push-gate-wrapper.sh
+++ b/skills/espalier-init/hook-templates/pre-push-gate-wrapper.sh
@@ -7,7 +7,8 @@
 # Bash invocations; this wrapper narrows the scope to push operations only.
 #
 # Exit-code contract: blocking paths exit with code 2 and the reason on stderr
-# (Claude Code PreToolUse semantics — exit code 1 would NOT block).
+# (PreToolUse semantics shared by Claude Code AND Codex — exit code 1 would
+# NOT block on either platform).
 
 INPUT=$(cat)
 
@@ -28,8 +29,15 @@ if [ -z "$PYBIN" ]; then
   echo "BLOCKED: espalier push gate cannot run — python3 not found (needed to parse the hook input). Install python3, or bypass once with ESPALIER_SKIP_GATE=1." >&2
   exit 2
 fi
-COMMAND=$(printf '%s' "$INPUT" | "$PYBIN" -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))") \
-  || { echo "BLOCKED: espalier push gate could not parse hook input JSON." >&2; exit 2; }
+# Codex's shell tool may send command as an argv ARRAY (["bash","-lc","git push"]);
+# Claude Code sends a string. Join arrays so the push-pattern grep below sees
+# plain words — printing the raw Python list would quote each element and the
+# quote-span stripper would then delete them (gate would fail OPEN).
+COMMAND=$(printf '%s' "$INPUT" | "$PYBIN" -c "
+import sys, json
+c = json.load(sys.stdin).get('tool_input', {}).get('command', '')
+print(' '.join(str(x) for x in c) if isinstance(c, list) else c)
+") || { echo "BLOCKED: espalier push gate could not parse hook input JSON." >&2; exit 2; }
 
 # Match a real `git push` invocation anywhere in the (possibly multi-line,
 # possibly `git -C dir push`) command. Strip quoted SPANS first (not whole lines)
@@ -40,9 +48,11 @@ if printf '%s\n' "$STRIPPED" \
    | grep -qE '(^|[;&|[:space:]])git([[:space:]]+(-C[[:space:]]*[^[:space:]]+|--?[[:alnum:]][^[:space:]]*))*[[:space:]]+push([[:space:]]|$)'; then
   # Run the gate from the repo root so its relative espalier/ paths resolve
   # regardless of the cwd the push was invoked from. Prefer the git toplevel;
-  # fall back to CLAUDE_PROJECT_DIR. A push from a subdir must NEVER silently
-  # skip the gate (that would fail OPEN — the exact hole this closes).
-  ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$CLAUDE_PROJECT_DIR")
+  # fall back to CLAUDE_PROJECT_DIR (Claude Code only — Codex doesn't set it,
+  # but under Codex the git fallback always resolves). A push from a subdir
+  # must NEVER silently skip the gate (that would fail OPEN — the exact hole
+  # this closes).
+  ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "${CLAUDE_PROJECT_DIR:-}")
   cd "$ROOT" || { echo "BLOCKED: cannot cd to repo root ($ROOT) to run the push gate." >&2; exit 2; }
   exec bash "$ROOT/espalier/hooks/pre-push-gate.sh"
 fi

--- a/skills/espalier-init/references/validation.md
+++ b/skills/espalier-init/references/validation.md
@@ -1,6 +1,8 @@
 # Phase 11: Validation (Dry Run)
 
-> **v0.4.0+ note:** Phase 11 runs via `scripts/bootstrap-espalier.sh` (Stage 11 of that script — 46 checks: 45 in parallel, plus #25 run serially so its per-tier table reaches stdout). Normal flow invokes this automatically. Manual usage: `bash scripts/bootstrap-espalier.sh --validate-only --plugin-dir=...` to re-run only the validation block (e.g., after manual file edits); add `--ignore-drift` to downgrade check #25's expired-drift hard fail to a logged override.
+> **v0.4.0+ note:** Phase 11 runs via `scripts/bootstrap-espalier.sh` (Stage 11 of that script — 46 checks when only claude is targeted, 51 with codex: all but #25 in parallel, #25 run serially so its per-tier table reaches stdout). Normal flow invokes this automatically. Manual usage: `bash scripts/bootstrap-espalier.sh --validate-only --plugin-dir=...` to re-run only the validation block (e.g., after manual file edits); add `--ignore-drift` to downgrade check #25's expired-drift hard fail to a logged override.
+>
+> **Platform gating (v0.14.0):** the platform set comes from `--platforms` unioned with `espalier/.platforms`. When claude is NOT targeted, checks 1-5 and 8 report `OK … (skipped — claude not targeted)`, and checks 13/14/29-33/35 swap their `.claude/…` paths for the `espalier/…` source equivalents. Checks 47-51 run only when codex IS targeted (claude-only installs still print exactly 46 lines — byte-stable with pre-v0.14 output).
 
 > **This table mirrors bootstrap-espalier.sh Stage 11 — update BOTH in the same commit.**
 
@@ -56,6 +58,11 @@ After all generation and wiring is complete, validate end-to-end.
 | 44 | wiki-external-services | `test -f espalier/wiki/external-services.md` | Re-run espalier-init Phase 2 (scout 1.10 → wiki write) |
 | 45 | rules-development-process | `test -f espalier/rules/development-process.md` | Re-run espalier-init Phase 2 (LLM write) |
 | 46 | layer-boundaries-hook | `test -f && test -x espalier/hooks/check-layer-boundaries.sh` | Phase 2 writes it for typescript/python/go; `--lang=unsupported` makes bootstrap write a no-op; `chmod +x` if present but not executable |
+| 47 | codex-skills-load *(codex only)* | `ls -d .agents/skills/espalier-coding … espalier-audit` (all 12 skill symlinks) | Re-run bootstrap Stage 5 with `--platforms=codex` (or `claude,codex`) |
+| 48 | codex-symlinks-valid *(codex only)* | `[ -L .agents/skills/espalier ] && [ -e … ]` | Broken link → source skill folder missing; re-run Stage 3/Phase 2, then Stage 5 |
+| 49 | codex-agents-toml *(codex only)* | `name = "harness-…"` present in all three `.codex/agents/harness-*.toml` | Re-run bootstrap Stage 8c (delete the bad file first — stage is write-if-absent) |
+| 50 | codex-hooks-configured *(codex only)* | `grep -q "espalier/hooks" .codex/config.toml` | Re-run bootstrap Stage 8b; if a stale `ESPALIER HOOKS` marker exists without the commands, delete the block and re-run |
+| 51 | codex-agentsmd *(codex only)* | `grep -q "## Espalier" AGENTS.md` | Re-run bootstrap Stage 7b |
 
 **Policy 3 — staleness tiers (check #25):** an artifact's age is measured from
 its `stale_first_seen` timestamp — fresh (<14d, silent), aging (14–30d, INFO),

--- a/skills/espalier-init/references/validation.md
+++ b/skills/espalier-init/references/validation.md
@@ -1,8 +1,8 @@
 # Phase 11: Validation (Dry Run)
 
-> **v0.4.0+ note:** Phase 11 runs via `scripts/bootstrap-espalier.sh` (Stage 11 of that script — 46 checks when only claude is targeted, 51 with codex: all but #25 in parallel, #25 run serially so its per-tier table reaches stdout). Normal flow invokes this automatically. Manual usage: `bash scripts/bootstrap-espalier.sh --validate-only --plugin-dir=...` to re-run only the validation block (e.g., after manual file edits); add `--ignore-drift` to downgrade check #25's expired-drift hard fail to a logged override.
+> **v0.4.0+ note:** Phase 11 runs via `scripts/bootstrap-espalier.sh` (Stage 11 of that script — 46 checks when only claude is targeted, 51 with codex, 56 with copilot: all but #25 in parallel, #25 run serially so its per-tier table reaches stdout). Normal flow invokes this automatically. Manual usage: `bash scripts/bootstrap-espalier.sh --validate-only --plugin-dir=...` to re-run only the validation block (e.g., after manual file edits); add `--ignore-drift` to downgrade check #25's expired-drift hard fail to a logged override.
 >
-> **Platform gating (v0.14.0):** the platform set comes from `--platforms` unioned with `espalier/.platforms`. When claude is NOT targeted, checks 1-5 and 8 report `OK … (skipped — claude not targeted)`, and checks 13/14/29-33/35 swap their `.claude/…` paths for the `espalier/…` source equivalents. Checks 47-51 run only when codex IS targeted (claude-only installs still print exactly 46 lines — byte-stable with pre-v0.14 output).
+> **Platform gating (v0.14.0/v0.15.0):** the platform set comes from `--platforms` unioned with `espalier/.platforms`. When claude is NOT targeted, checks 1-5 and 8 report `OK … (skipped — claude not targeted)`, and checks 13/14/29-33/35 swap their `.claude/…` paths for the `espalier/…` source equivalents. Checks 47-51 run when codex is targeted (skip-rendered when only copilot forces the range); checks 52-56 run only when copilot is targeted. Claude-only installs still print exactly 46 lines — byte-stable with pre-v0.14 output.
 
 > **This table mirrors bootstrap-espalier.sh Stage 11 — update BOTH in the same commit.**
 
@@ -63,6 +63,13 @@ After all generation and wiring is complete, validate end-to-end.
 | 49 | codex-agents-toml *(codex only)* | `name = "harness-…"` present in all three `.codex/agents/harness-*.toml` | Re-run bootstrap Stage 8c (delete the bad file first — stage is write-if-absent) |
 | 50 | codex-hooks-configured *(codex only)* | `grep -q "espalier/hooks" .codex/config.toml` | Re-run bootstrap Stage 8b; if a stale `ESPALIER HOOKS` marker exists without the commands, delete the block and re-run |
 | 51 | codex-agentsmd *(codex only)* | `grep -q "## Espalier" AGENTS.md` | Re-run bootstrap Stage 7b |
+| 52 | copilot-skills-load *(copilot only)* | `ls -d .github/skills/espalier-coding … espalier-audit` (all 12 skill symlinks) | Re-run bootstrap Stage 5 with copilot in `--platforms` |
+| 53 | copilot-symlinks-valid *(copilot only)* | `[ -L .github/skills/espalier ] && [ -e … ]` | Broken link → source skill folder missing; re-run Stage 3/Phase 2, then Stage 5 |
+| 54 | copilot-agents *(copilot only)* | `name: harness-…` present in all three `.github/agents/harness-*.agent.md` | Re-run bootstrap Stage 8d (delete the bad file first — stage is write-if-absent) |
+| 55 | copilot-hooks-json *(copilot only)* | `espalier-gates.json` parses as JSON, references `copilot-hook-adapter`, and the adapter is executable | Re-run bootstrap Stage 8e (delete the bad file first); `chmod +x espalier/hooks/copilot-hook-adapter.sh` |
+| 56 | copilot-instructions *(copilot only)* | `grep -q "## Espalier" .github/copilot-instructions.md` | Re-run bootstrap Stage 7c |
+
+When copilot is targeted WITHOUT codex, checks 47-51 print as `OK … (skipped — codex not targeted)` so numbering stays contiguous; totals: 46 (claude-only) / 51 (+codex) / 56 (+copilot).
 
 **Policy 3 — staleness tiers (check #25):** an artifact's age is measured from
 its `stale_first_seen` timestamp — fresh (<14d, silent), aging (14–30d, INFO),

--- a/skills/espalier-init/references/wiring.md
+++ b/skills/espalier-init/references/wiring.md
@@ -1,6 +1,13 @@
-# Phase 10: Wiring (Connect Espalier to Claude Code Runtime)
+# Phase 10: Wiring (Connect Espalier to the Agent Runtime)
 
 > **v0.5.0 note:** `scripts/bootstrap-espalier.sh` is the source of truth for wiring — it bundles all of Phase 10 (Stages 5-11) and is kept current. The manual steps below are a **v0.4-era illustration** of *what* wiring does; they do NOT include the v0.5 doc-drift components — the `drift-detect.sh` / `drift-helpers.sh` / `parse-drift-blocks.py` hooks, the `espalier-prune` + `espalier-doctor` skills, the post-merge dispatcher, the drift sidecars in `.gitignore`, and `espalier/.doctor-cadence`. For real manual recovery after a failed wiring, re-run `bash scripts/bootstrap-espalier.sh --wire-only` (or `--force`) — do not hand-replay the steps below.
+>
+> **v0.14.0 note (Codex platform):** with `--platforms=codex` (or `claude,codex`) bootstrap additionally wires the Codex runtime — none of it is illustrated in the Claude-era steps below:
+> - `.agents/skills/<name>` → `../../espalier/skills/<name>` symlinks (Codex repo-skill discovery probes `.agents/skills/`; same folder-name == `name:` frontmatter invariant, invoked as `$espalier`, `$espalier-fix`, …).
+> - `AGENTS.md` `## Espalier` section (grep-guarded append) — carries the always-read-rules instruction (Codex has no auto-loaded rules dir) plus the Codex platform-mapping table (AskUserQuestion → chat, sub-agent spawn → `.codex/agents/`, `/cmd` → `$skill`).
+> - `.codex/config.toml` marker-guarded hook block (`# >>> ESPALIER HOOKS v1 >>>` … `# <<<`): PostToolUse matcher `^(apply_patch|Edit|Write)$` → `post-edit-wrapper.sh`; PreToolUse matcher `^(Bash|shell|local_shell)$` → `pre-push-gate-wrapper.sh`. Same stdin JSON schema and exit-2-blocks contract as Claude Code, so the SAME wrapper scripts serve both platforms. Project hooks require the project to be trusted AND `/hooks` trust once inside Codex.
+> - `.codex/agents/harness-{coder,reviewer,security}.toml` sub-agents (write-if-absent — user model/effort tuning survives re-runs), each pointing `developer_instructions` at the matching `espalier/agents/*.md`.
+> - `espalier/.platforms` records the wired platform set; re-runs are additive (a later `--wire-only --platforms=codex` on a claude install unions to `claude,codex` and never unwires anything).
 
 Generated files are inert until wired into the execution environment. Run these steps in order.
 

--- a/skills/espalier-init/references/wiring.md
+++ b/skills/espalier-init/references/wiring.md
@@ -8,6 +8,13 @@
 > - `.codex/config.toml` marker-guarded hook block (`# >>> ESPALIER HOOKS v1 >>>` … `# <<<`): PostToolUse matcher `^(apply_patch|Edit|Write)$` → `post-edit-wrapper.sh`; PreToolUse matcher `^(Bash|shell|local_shell)$` → `pre-push-gate-wrapper.sh`. Same stdin JSON schema and exit-2-blocks contract as Claude Code, so the SAME wrapper scripts serve both platforms. Project hooks require the project to be trusted AND `/hooks` trust once inside Codex.
 > - `.codex/agents/harness-{coder,reviewer,security}.toml` sub-agents (write-if-absent — user model/effort tuning survives re-runs), each pointing `developer_instructions` at the matching `espalier/agents/*.md`.
 > - `espalier/.platforms` records the wired platform set; re-runs are additive (a later `--wire-only --platforms=codex` on a claude install unions to `claude,codex` and never unwires anything).
+>
+> **v0.15.0 note (Copilot platform):** with `copilot` in `--platforms` bootstrap additionally wires GitHub Copilot:
+> - `.github/skills/<name>` → `../../espalier/skills/<name>` symlinks (Copilot Agent Skills — the one location ALL Copilot surfaces read: VS Code, CLI, cloud coding agent; VS Code alone also reads `.claude/skills/` and `.agents/skills/`). Invoked `/espalier`, `/espalier-fix`, … Same folder-name == `name:` invariant.
+> - `.github/copilot-instructions.md` `## Espalier` section (grep-guarded append) — always-read-rules instruction + the Copilot platform-mapping table (`@harness-*` custom agents, hook surface caveats).
+> - `.github/agents/harness-{coder,reviewer,security}.agent.md` custom agents (write-if-absent; body points at the matching `espalier/agents/*.md`; invoked `@harness-coder` etc.).
+> - `.github/hooks/espalier-gates.json` (write-if-absent, own file — user hook files untouched): `preToolUse` matcher `bash|shell` and `postToolUse` matcher `edit|write|create|apply_patch|str_replace_editor`, each dispatching through `espalier/hooks/copilot-hook-adapter.sh`, which translates Copilot's camelCase payload (`toolName`/`toolArgs`) into the Claude/Codex shape (`tool_name`/`tool_input`) and passes exit codes through — Copilot treats a non-zero `preToolUse` exit as DENY (fail-closed), so the shared wrappers' exit-2 contract carries over. Hooks run in Copilot CLI + cloud agent; VS Code chat does not execute hooks.
+> - Validation checks 52-56; totals become 56 (47-51 render as skip lines when codex isn't also targeted, keeping numbering contiguous).
 
 Generated files are inert until wired into the execution environment. Run these steps in order.
 

--- a/skills/espalier-migrate/SKILL.md
+++ b/skills/espalier-migrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: espalier-migrate
-description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5, the v0.5.3 coder-agent patch, v0.5→v0.6 (Stage 1 grill), v0.6→v0.7 (read-only /espalier-ask lane), v0.7→v0.8 (requirements approval gate), the v0.8.1 impact-analysis agent patch, the v0.8.2 re-review fixpoint loop, the v0.9.0 security audit, the v0.9.1 configurable escalation caps, the v0.9.2 correctness patch, the v0.9.3 skill-clarity patch, the v0.9.4 security-skill patch, the v0.9.6→v0.10.0 push-gate reshape, the v0.10.0→v0.11.0 hook exit-code release, the v0.11.0→v0.12.0 grill blind-spot pass (Stage 1 rules/wiki cross-check), the v0.12.0→v0.13.0 minimalism release (coder Solution Selection Ladder + reviewer advisory Minimalism Review), the v0.13.0→v0.13.1 polish patch (stage-conditional coding guidance + reviewer step-7 abuse-test duty + code-review gate line), the v0.13.1→v0.13.2 readability release (coder clarity-then-brevity tie-break + comment-convention discovery + reviewer advisory Readability Review with the cryptic-public-name P1), and the v0.13.2→v0.14.0 Codex platform release (platform-neutral hook wrappers + optional .agents/skills + AGENTS.md + .codex wiring) you need and applies them in order.
+description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5, the v0.5.3 coder-agent patch, v0.5→v0.6 (Stage 1 grill), v0.6→v0.7 (read-only /espalier-ask lane), v0.7→v0.8 (requirements approval gate), the v0.8.1 impact-analysis agent patch, the v0.8.2 re-review fixpoint loop, the v0.9.0 security audit, the v0.9.1 configurable escalation caps, the v0.9.2 correctness patch, the v0.9.3 skill-clarity patch, the v0.9.4 security-skill patch, the v0.9.6→v0.10.0 push-gate reshape, the v0.10.0→v0.11.0 hook exit-code release, the v0.11.0→v0.12.0 grill blind-spot pass (Stage 1 rules/wiki cross-check), the v0.12.0→v0.13.0 minimalism release (coder Solution Selection Ladder + reviewer advisory Minimalism Review), the v0.13.0→v0.13.1 polish patch (stage-conditional coding guidance + reviewer step-7 abuse-test duty + code-review gate line), the v0.13.1→v0.13.2 readability release (coder clarity-then-brevity tie-break + comment-convention discovery + reviewer advisory Readability Review with the cryptic-public-name P1), the v0.13.2→v0.14.0 Codex platform release (platform-neutral hook wrappers + optional .agents/skills + AGENTS.md + .codex wiring), and the v0.14.0→v0.15.0 Copilot platform release (camelCase hook adapter + optional .github/skills + copilot-instructions + .github/agents + .github/hooks wiring) you need and applies them in order.
 ---
 
 # Espalier Migration Runner
@@ -18,7 +18,7 @@ description: Migrate an existing harness/espalier install to the current Espalie
 ## Instructions
 
 You are running a migration of an existing install to the current Espalier
-version. Up to TWENTY-ONE migrations may apply, always in this order:
+version. Up to TWENTY-TWO migrations may apply, always in this order:
 
 1. **v0.1.x → v0.2.x** — typed `harness/changes/{type}/{slug}/` layout,
    `/harness-fix` lane, squash-merge decision. Mechanical:
@@ -213,24 +213,37 @@ version. Up to TWENTY-ONE migrations may apply, always in this order:
    sub-agents, `espalier/.platforms`. Never unwires claude. Backs up to
    `<wrapper>.pre-v0.14.bak`. Mechanical:
    `scripts/migrate-v0.13.2-to-v0.14.0.sh`.
+22. **v0.14.0 → v0.15.0** — Copilot platform release. Always: installs the new
+   plugin-owned Copilot hook shim `espalier/hooks/copilot-hook-adapter.sh`
+   (translates Copilot's camelCase `toolName`/`toolArgs` payload into the
+   Claude/Codex `tool_name`/`tool_input` shape and dispatches to the shared
+   wrappers; exit codes pass through — Copilot treats non-zero `preToolUse`
+   exits as DENY). Optional (`--with-copilot`, asked in Step 4c): wires the
+   copilot platform additively — `.github/skills/` symlinks,
+   `.github/copilot-instructions.md` Espalier section,
+   `.github/agents/harness-*.agent.md` custom agents,
+   `.github/hooks/espalier-gates.json`. Never unwires claude/codex. New file
+   only — no backups needed. Mechanical:
+   `scripts/migrate-v0.14.0-to-v0.15.0.sh`.
 
 Your job: detect which one(s) apply, locate the scripts, preview, get
-confirmation, apply in order. A v0.1.x install needs ALL TWENTY-ONE; a v0.3.x
-install needs the last twenty; a v0.4.x install needs the last nineteen; a
-v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.14.0; a
-v0.5.3–v0.5.x install needs v0.6 … v0.14.0; a v0.6.x install needs
-v0.7 … v0.14.0; a v0.7.x install needs v0.8 … v0.14.0; a v0.8.0 install needs
-v0.8.1 … v0.14.0; a v0.8.1 install needs v0.8.2 … v0.14.0; a v0.8.2 install
-needs v0.9.0 … v0.14.0; a v0.9.0 install needs v0.9.1 … v0.14.0; a v0.9.1
-install needs v0.9.2 … v0.14.0; a v0.9.2 install needs v0.9.3, v0.9.4,
-v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, v0.13.2, then v0.14.0; a v0.9.3 install
-needs v0.9.4, v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, v0.13.2, then v0.14.0; a
+confirmation, apply in order. A v0.1.x install needs ALL TWENTY-TWO; a v0.3.x
+install needs the last twenty-one; a v0.4.x install needs the last twenty; a
+v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.15.0; a
+v0.5.3–v0.5.x install needs v0.6 … v0.15.0; a v0.6.x install needs
+v0.7 … v0.15.0; a v0.7.x install needs v0.8 … v0.15.0; a v0.8.0 install needs
+v0.8.1 … v0.15.0; a v0.8.1 install needs v0.8.2 … v0.15.0; a v0.8.2 install
+needs v0.9.0 … v0.15.0; a v0.9.0 install needs v0.9.1 … v0.15.0; a v0.9.1
+install needs v0.9.2 … v0.15.0; a v0.9.2 install needs v0.9.3, v0.9.4,
+v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, v0.13.2, v0.14.0, then v0.15.0; a v0.9.3 install
+needs v0.9.4, v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, v0.13.2, v0.14.0, then v0.15.0; a
 v0.9.4, v0.9.5, or v0.9.6 install needs v0.10.0, v0.11.0, v0.12.0, v0.13.0,
-v0.13.1, v0.13.2, then v0.14.0; a v0.10.0 install needs v0.11.0, v0.12.0, v0.13.0,
-v0.13.1, v0.13.2, then v0.14.0; a v0.11.0 install needs v0.12.0, v0.13.0, v0.13.1,
-v0.13.2, then v0.14.0; a v0.12.0 install needs v0.13.0, v0.13.1, v0.13.2, then
-v0.14.0; a v0.13.0 install needs v0.13.1, v0.13.2, then v0.14.0; a v0.13.1
-install needs v0.13.2 then v0.14.0; a v0.13.2 install needs only v0.14.0.
+v0.13.1, v0.13.2, v0.14.0, then v0.15.0; a v0.10.0 install needs v0.11.0, v0.12.0, v0.13.0,
+v0.13.1, v0.13.2, v0.14.0, then v0.15.0; a v0.11.0 install needs v0.12.0, v0.13.0, v0.13.1,
+v0.13.2, v0.14.0, then v0.15.0; a v0.12.0 install needs v0.13.0, v0.13.1, v0.13.2, v0.14.0, then
+v0.15.0; a v0.13.0 install needs v0.13.1, v0.13.2, v0.14.0, then v0.15.0; a v0.13.1
+install needs v0.13.2, v0.14.0, then v0.15.0; a v0.13.2 install needs v0.14.0
+then v0.15.0; a v0.14.0 install needs only v0.15.0.
 
 Two gaps in the script names are deliberate, not missing steps: there is no
 v0.2→v0.3 script because v0.2/v0.3 detection is lumped — the v0.3→v0.4 step
@@ -271,6 +284,7 @@ NEEDS_V0130_PATCH=no
 NEEDS_V0131_PATCH=no
 NEEDS_V0132_PATCH=no
 NEEDS_V0140_PATCH=no
+NEEDS_V0150_PATCH=no
 
 if [ ! -d "harness" ] && [ ! -d "espalier" ]; then
   echo "ERROR: no harness/ or espalier/ dir found — not a target install."
@@ -303,6 +317,7 @@ if [ -d "harness" ]; then
   NEEDS_V0131_PATCH=yes      # ...then the v0.13.1 minimalism polish patch
   NEEDS_V0132_PATCH=yes      # ...then the v0.13.2 readability release
   NEEDS_V0140_PATCH=yes      # ...then the v0.14.0 codex platform release
+  NEEDS_V0150_PATCH=yes      # ...then the v0.15.0 copilot platform release
 elif [ -d "espalier" ]; then
   # Already renamed. v0.4.x still needs the doc-drift upgrade.
   if [ ! -f "espalier/hooks/drift-detect.sh" ] || [ ! -f "espalier/.doctor-cadence" ]; then
@@ -494,6 +509,13 @@ elif [ -d "espalier" ]; then
      || ! grep -qF -- 'isinstance(c, list)' espalier/hooks/pre-push-gate-wrapper.sh 2>/dev/null; then
     NEEDS_V0140_PATCH=yes
   fi
+  # v0.15.0: the copilot platform release. The always-delta is one NEW
+  # plugin-owned file — the camelCase hook shim. Keep in sync with
+  # migrate-v0.14.0-to-v0.15.0.sh's own idempotency check. (Copilot WIRING is
+  # opt-in and never a detection signal.)
+  if [ ! -f espalier/hooks/copilot-hook-adapter.sh ]; then
+    NEEDS_V0150_PATCH=yes
+  fi
 fi
 
 if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
@@ -506,7 +528,7 @@ if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
    && [ "$NEEDS_V0100_PATCH" = no ] && [ "$NEEDS_V0110_PATCH" = no ] \
    && [ "$NEEDS_V0120_PATCH" = no ] && [ "$NEEDS_V0130_PATCH" = no ] \
    && [ "$NEEDS_V0131_PATCH" = no ] && [ "$NEEDS_V0132_PATCH" = no ] \
-   && [ "$NEEDS_V0140_PATCH" = no ]; then
+   && [ "$NEEDS_V0140_PATCH" = no ] && [ "$NEEDS_V0150_PATCH" = no ]; then
   echo "Already fully up to date. Nothing to do."
   exit 0
 fi
@@ -527,7 +549,7 @@ never a stray `$HOME` checkout that merely shares the name.
 PLUGIN_DIR=""
 # Primary: derive the plugin root from the skill's own location.
 if [ -n "${CLAUDE_SKILL_DIR:-}" ] \
-   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.13.2-to-v0.14.0.sh" ]; then
+   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.14.0-to-v0.15.0.sh" ]; then
   PLUGIN_DIR="$(cd "${CLAUDE_SKILL_DIR}/../.." && pwd)"
 fi
 
@@ -536,7 +558,7 @@ fi
 if [ -z "$PLUGIN_DIR" ]; then
   for candidate in "${ESPALIER_PLUGIN_DIR:-}" "$HOME/repos/espalier-engineering"; do
     [ -n "$candidate" ] || continue
-    if [ -f "$candidate/scripts/migrate-v0.13.2-to-v0.14.0.sh" ]; then
+    if [ -f "$candidate/scripts/migrate-v0.14.0-to-v0.15.0.sh" ]; then
       PLUGIN_DIR="$candidate"
       break
     fi
@@ -554,7 +576,7 @@ fi
 The probe is the NEWEST migration script, so a plugin that predates the current
 chain fails to resolve rather than resolving and then dying on a missing script
 mid-apply. If the primary path misses and the fallback fires, the plugin install
-is likely stale (no `migrate-v0.13.2-to-v0.14.0.sh`) — tell the user to
+is likely stale (no `migrate-v0.14.0-to-v0.15.0.sh`) — tell the user to
 `/plugin update espalier-engineering` first. Bump this probe whenever a new
 migration script is added.
 
@@ -585,6 +607,7 @@ verbatim:
 [ "$NEEDS_V0131_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.0-to-v0.13.1.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0132_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.1-to-v0.13.2.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0140_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.2-to-v0.14.0.sh" --dry-run --plugin-dir="$PLUGIN_DIR" $WITH_CODEX_FLAG
+[ "$NEEDS_V0150_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.14.0-to-v0.15.0.sh" --dry-run --plugin-dir="$PLUGIN_DIR" $WITH_COPILOT_FLAG
 ```
 
 A dry-run for a step whose prerequisite has not been applied yet may refuse with
@@ -630,6 +653,27 @@ Cache the literal flag string as `$WITH_CODEX_FLAG` and substitute it into the
 Step 3 dry-run and Step 6 apply commands (it expands to nothing when empty).
 Wiring later is one command: `bash <plugin>/scripts/migrate-v0.13.2-to-v0.14.0.sh --with-codex --yes`.
 
+### Step 4c: If v0.15.0 applies, ask about Copilot wiring
+
+The adapter install always runs; the Copilot WIRING is opt-in. Skip the
+question entirely if `grep -q copilot espalier/.platforms` already succeeds
+(wired — set `WITH_COPILOT_FLAG=""`). Otherwise ask (`AskUserQuestion`):
+
+```
+v0.15.0 can additionally wire this repo for GitHub Copilot: .github/skills/
+symlinks (Agent Skills for VS Code / CLI / cloud agent), a
+.github/copilot-instructions.md Espalier section, @harness-* custom agents,
+and .github/hooks quality gates. Claude/Codex wiring is untouched.
+
+  1. Yes — teammates (or I) use Copilot here   → WITH_COPILOT_FLAG=--with-copilot
+  2. No — not needed (default)                  → WITH_COPILOT_FLAG=""
+```
+
+Cache the literal flag string as `$WITH_COPILOT_FLAG` and substitute it into
+the Step 3 dry-run and Step 6 apply commands (it expands to nothing when
+empty). Wiring later is one command:
+`bash <plugin>/scripts/migrate-v0.14.0-to-v0.15.0.sh --with-copilot --yes`.
+
 ### Step 5: Confirm with the user
 
 Use `AskUserQuestion`:
@@ -670,6 +714,7 @@ completed.
 [ "$NEEDS_V0131_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.0-to-v0.13.1.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0132_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.1-to-v0.13.2.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0140_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.2-to-v0.14.0.sh" --yes --plugin-dir="$PLUGIN_DIR" $WITH_CODEX_FLAG
+[ "$NEEDS_V0150_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.14.0-to-v0.15.0.sh" --yes --plugin-dir="$PLUGIN_DIR" $WITH_COPILOT_FLAG
 ```
 
 Each script's verification block prints `X passed, Y failed`. Surface every

--- a/skills/espalier-migrate/SKILL.md
+++ b/skills/espalier-migrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: espalier-migrate
-description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5, the v0.5.3 coder-agent patch, v0.5→v0.6 (Stage 1 grill), v0.6→v0.7 (read-only /espalier-ask lane), v0.7→v0.8 (requirements approval gate), the v0.8.1 impact-analysis agent patch, the v0.8.2 re-review fixpoint loop, the v0.9.0 security audit, the v0.9.1 configurable escalation caps, the v0.9.2 correctness patch, the v0.9.3 skill-clarity patch, the v0.9.4 security-skill patch, the v0.9.6→v0.10.0 push-gate reshape, the v0.10.0→v0.11.0 hook exit-code release, the v0.11.0→v0.12.0 grill blind-spot pass (Stage 1 rules/wiki cross-check), the v0.12.0→v0.13.0 minimalism release (coder Solution Selection Ladder + reviewer advisory Minimalism Review), the v0.13.0→v0.13.1 polish patch (stage-conditional coding guidance + reviewer step-7 abuse-test duty + code-review gate line), and the v0.13.1→v0.13.2 readability release (coder clarity-then-brevity tie-break + comment-convention discovery + reviewer advisory Readability Review with the cryptic-public-name P1) you need and applies them in order.
+description: Migrate an existing harness/espalier install to the current Espalier version — auto-detects which of v0.1→v0.2, v0.3→v0.4, v0.4→v0.5, the v0.5.3 coder-agent patch, v0.5→v0.6 (Stage 1 grill), v0.6→v0.7 (read-only /espalier-ask lane), v0.7→v0.8 (requirements approval gate), the v0.8.1 impact-analysis agent patch, the v0.8.2 re-review fixpoint loop, the v0.9.0 security audit, the v0.9.1 configurable escalation caps, the v0.9.2 correctness patch, the v0.9.3 skill-clarity patch, the v0.9.4 security-skill patch, the v0.9.6→v0.10.0 push-gate reshape, the v0.10.0→v0.11.0 hook exit-code release, the v0.11.0→v0.12.0 grill blind-spot pass (Stage 1 rules/wiki cross-check), the v0.12.0→v0.13.0 minimalism release (coder Solution Selection Ladder + reviewer advisory Minimalism Review), the v0.13.0→v0.13.1 polish patch (stage-conditional coding guidance + reviewer step-7 abuse-test duty + code-review gate line), the v0.13.1→v0.13.2 readability release (coder clarity-then-brevity tie-break + comment-convention discovery + reviewer advisory Readability Review with the cryptic-public-name P1), and the v0.13.2→v0.14.0 Codex platform release (platform-neutral hook wrappers + optional .agents/skills + AGENTS.md + .codex wiring) you need and applies them in order.
 ---
 
 # Espalier Migration Runner
@@ -18,7 +18,7 @@ description: Migrate an existing harness/espalier install to the current Espalie
 ## Instructions
 
 You are running a migration of an existing install to the current Espalier
-version. Up to NINETEEN migrations may apply, always in this order:
+version. Up to TWENTY-ONE migrations may apply, always in this order:
 
 1. **v0.1.x → v0.2.x** — typed `harness/changes/{type}/{slug}/` layout,
    `/harness-fix` lane, squash-merge decision. Mechanical:
@@ -202,24 +202,35 @@ version. Up to NINETEEN migrations may apply, always in this order:
    placeholders until `/espalier-prune` re-scouts. Backs up to
    `<file>.pre-v0.13.2.bak`. Mechanical:
    `scripts/migrate-v0.13.1-to-v0.13.2.sh`.
+21. **v0.13.2 → v0.14.0** — Codex platform release. Always: refreshes the two
+   plugin-owned hook wrappers (`post-edit-wrapper.sh` now parses Codex
+   apply_patch input and resolves the repo root without
+   `$CLAUDE_PROJECT_DIR`; `pre-push-gate-wrapper.sh` now joins argv-array
+   commands before the git-push match — both inert on Claude Code). Optional
+   (`--with-codex`, asked in Step 4b): wires the codex platform additively —
+   `.agents/skills/` symlinks, `AGENTS.md` Espalier section + platform
+   mapping, `.codex/config.toml` hook block, `.codex/agents/harness-*.toml`
+   sub-agents, `espalier/.platforms`. Never unwires claude. Backs up to
+   `<wrapper>.pre-v0.14.bak`. Mechanical:
+   `scripts/migrate-v0.13.2-to-v0.14.0.sh`.
 
 Your job: detect which one(s) apply, locate the scripts, preview, get
-confirmation, apply in order. A v0.1.x install needs ALL TWENTY; a v0.3.x
-install needs the last nineteen; a v0.4.x install needs the last eighteen; a
-v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.13.2; a
-v0.5.3–v0.5.x install needs v0.6 … v0.13.2; a v0.6.x install needs
-v0.7 … v0.13.2; a v0.7.x install needs v0.8 … v0.13.2; a v0.8.0 install needs
-v0.8.1 … v0.13.2; a v0.8.1 install needs v0.8.2 … v0.13.2; a v0.8.2 install
-needs v0.9.0 … v0.13.2; a v0.9.0 install needs v0.9.1 … v0.13.2; a v0.9.1
-install needs v0.9.2 … v0.13.2; a v0.9.2 install needs v0.9.3, v0.9.4,
-v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, then v0.13.2; a v0.9.3 install
-needs v0.9.4, v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, then v0.13.2; a
+confirmation, apply in order. A v0.1.x install needs ALL TWENTY-ONE; a v0.3.x
+install needs the last twenty; a v0.4.x install needs the last nineteen; a
+v0.5.0–v0.5.2 install needs the v0.5.3 patch then v0.6 … v0.14.0; a
+v0.5.3–v0.5.x install needs v0.6 … v0.14.0; a v0.6.x install needs
+v0.7 … v0.14.0; a v0.7.x install needs v0.8 … v0.14.0; a v0.8.0 install needs
+v0.8.1 … v0.14.0; a v0.8.1 install needs v0.8.2 … v0.14.0; a v0.8.2 install
+needs v0.9.0 … v0.14.0; a v0.9.0 install needs v0.9.1 … v0.14.0; a v0.9.1
+install needs v0.9.2 … v0.14.0; a v0.9.2 install needs v0.9.3, v0.9.4,
+v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, v0.13.2, then v0.14.0; a v0.9.3 install
+needs v0.9.4, v0.10.0, v0.11.0, v0.12.0, v0.13.0, v0.13.1, v0.13.2, then v0.14.0; a
 v0.9.4, v0.9.5, or v0.9.6 install needs v0.10.0, v0.11.0, v0.12.0, v0.13.0,
-v0.13.1, then v0.13.2; a v0.10.0 install needs v0.11.0, v0.12.0, v0.13.0,
-v0.13.1, then v0.13.2; a v0.11.0 install needs v0.12.0, v0.13.0, v0.13.1,
-then v0.13.2; a v0.12.0 install needs v0.13.0, v0.13.1, then v0.13.2; a
-v0.13.0 install needs v0.13.1 then v0.13.2; a v0.13.1 install needs only
-v0.13.2.
+v0.13.1, v0.13.2, then v0.14.0; a v0.10.0 install needs v0.11.0, v0.12.0, v0.13.0,
+v0.13.1, v0.13.2, then v0.14.0; a v0.11.0 install needs v0.12.0, v0.13.0, v0.13.1,
+v0.13.2, then v0.14.0; a v0.12.0 install needs v0.13.0, v0.13.1, v0.13.2, then
+v0.14.0; a v0.13.0 install needs v0.13.1, v0.13.2, then v0.14.0; a v0.13.1
+install needs v0.13.2 then v0.14.0; a v0.13.2 install needs only v0.14.0.
 
 Two gaps in the script names are deliberate, not missing steps: there is no
 v0.2→v0.3 script because v0.2/v0.3 detection is lumped — the v0.3→v0.4 step
@@ -259,6 +270,7 @@ NEEDS_V0120_PATCH=no
 NEEDS_V0130_PATCH=no
 NEEDS_V0131_PATCH=no
 NEEDS_V0132_PATCH=no
+NEEDS_V0140_PATCH=no
 
 if [ ! -d "harness" ] && [ ! -d "espalier" ]; then
   echo "ERROR: no harness/ or espalier/ dir found — not a target install."
@@ -290,6 +302,7 @@ if [ -d "harness" ]; then
   NEEDS_V0130_PATCH=yes      # ...then the v0.13.0 minimalism release
   NEEDS_V0131_PATCH=yes      # ...then the v0.13.1 minimalism polish patch
   NEEDS_V0132_PATCH=yes      # ...then the v0.13.2 readability release
+  NEEDS_V0140_PATCH=yes      # ...then the v0.14.0 codex platform release
 elif [ -d "espalier" ]; then
   # Already renamed. v0.4.x still needs the doc-drift upgrade.
   if [ ! -f "espalier/hooks/drift-detect.sh" ] || [ ! -f "espalier/.doctor-cadence" ]; then
@@ -472,6 +485,15 @@ elif [ -d "espalier" ]; then
      || ! grep -qF -- 'Readability: names state intent' espalier/skills/espalier-review/SKILL.md 2>/dev/null; then
     NEEDS_V0132_PATCH=yes
   fi
+  # v0.14.0: the codex platform release. The two plugin-owned hook wrappers
+  # become platform-neutral (Codex apply_patch parsing; argv-array join). Any
+  # marker missing ⇒ pre-v0.14.0. Keep in sync with
+  # migrate-v0.13.2-to-v0.14.0.sh's own idempotency check. (Codex WIRING is
+  # opt-in and never a detection signal — a claude-only install is complete.)
+  if ! grep -qF -- 'apply_patch' espalier/hooks/post-edit-wrapper.sh 2>/dev/null \
+     || ! grep -qF -- 'isinstance(c, list)' espalier/hooks/pre-push-gate-wrapper.sh 2>/dev/null; then
+    NEEDS_V0140_PATCH=yes
+  fi
 fi
 
 if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
@@ -483,7 +505,8 @@ if [ "$NEEDS_V01_V02" = no ] && [ "$NEEDS_V03_V04" = no ] \
    && [ "$NEEDS_V093_PATCH" = no ] && [ "$NEEDS_V094_PATCH" = no ] \
    && [ "$NEEDS_V0100_PATCH" = no ] && [ "$NEEDS_V0110_PATCH" = no ] \
    && [ "$NEEDS_V0120_PATCH" = no ] && [ "$NEEDS_V0130_PATCH" = no ] \
-   && [ "$NEEDS_V0131_PATCH" = no ] && [ "$NEEDS_V0132_PATCH" = no ]; then
+   && [ "$NEEDS_V0131_PATCH" = no ] && [ "$NEEDS_V0132_PATCH" = no ] \
+   && [ "$NEEDS_V0140_PATCH" = no ]; then
   echo "Already fully up to date. Nothing to do."
   exit 0
 fi
@@ -504,7 +527,7 @@ never a stray `$HOME` checkout that merely shares the name.
 PLUGIN_DIR=""
 # Primary: derive the plugin root from the skill's own location.
 if [ -n "${CLAUDE_SKILL_DIR:-}" ] \
-   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.13.1-to-v0.13.2.sh" ]; then
+   && [ -f "${CLAUDE_SKILL_DIR}/../../scripts/migrate-v0.13.2-to-v0.14.0.sh" ]; then
   PLUGIN_DIR="$(cd "${CLAUDE_SKILL_DIR}/../.." && pwd)"
 fi
 
@@ -513,7 +536,7 @@ fi
 if [ -z "$PLUGIN_DIR" ]; then
   for candidate in "${ESPALIER_PLUGIN_DIR:-}" "$HOME/repos/espalier-engineering"; do
     [ -n "$candidate" ] || continue
-    if [ -f "$candidate/scripts/migrate-v0.13.1-to-v0.13.2.sh" ]; then
+    if [ -f "$candidate/scripts/migrate-v0.13.2-to-v0.14.0.sh" ]; then
       PLUGIN_DIR="$candidate"
       break
     fi
@@ -531,7 +554,7 @@ fi
 The probe is the NEWEST migration script, so a plugin that predates the current
 chain fails to resolve rather than resolving and then dying on a missing script
 mid-apply. If the primary path misses and the fallback fires, the plugin install
-is likely stale (no `migrate-v0.13.1-to-v0.13.2.sh`) — tell the user to
+is likely stale (no `migrate-v0.13.2-to-v0.14.0.sh`) — tell the user to
 `/plugin update espalier-engineering` first. Bump this probe whenever a new
 migration script is added.
 
@@ -561,6 +584,7 @@ verbatim:
 [ "$NEEDS_V0130_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.12.0-to-v0.13.0.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0131_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.0-to-v0.13.1.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0132_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.1-to-v0.13.2.sh" --dry-run --plugin-dir="$PLUGIN_DIR"
+[ "$NEEDS_V0140_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.2-to-v0.14.0.sh" --dry-run --plugin-dir="$PLUGIN_DIR" $WITH_CODEX_FLAG
 ```
 
 A dry-run for a step whose prerequisite has not been applied yet may refuse with
@@ -586,6 +610,25 @@ A scan is activity-gated — an idle repo never triggers one.
 
 Cache the answer as `$DOCTOR_CADENCE` (default `weekly`). It is editable later
 in `espalier/.doctor-cadence`.
+
+### Step 4b: If v0.14.0 applies, ask about Codex wiring
+
+The wrapper refresh always runs; the Codex WIRING is opt-in. Skip the question
+entirely if `grep -q codex espalier/.platforms` already succeeds (wired — set
+`WITH_CODEX_FLAG=""`). Otherwise ask (`AskUserQuestion`):
+
+```
+v0.14.0 can additionally wire this repo for Codex (OpenAI's coding agent):
+.agents/skills/ symlinks, an AGENTS.md Espalier section, .codex/config.toml
+quality-gate hooks, and .codex/agents/ sub-agents. Claude wiring is untouched.
+
+  1. Yes — teammates (or I) use Codex here   → WITH_CODEX_FLAG=--with-codex
+  2. No — Claude Code only (default)          → WITH_CODEX_FLAG=""
+```
+
+Cache the literal flag string as `$WITH_CODEX_FLAG` and substitute it into the
+Step 3 dry-run and Step 6 apply commands (it expands to nothing when empty).
+Wiring later is one command: `bash <plugin>/scripts/migrate-v0.13.2-to-v0.14.0.sh --with-codex --yes`.
 
 ### Step 5: Confirm with the user
 
@@ -626,6 +669,7 @@ completed.
 [ "$NEEDS_V0130_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.12.0-to-v0.13.0.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0131_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.0-to-v0.13.1.sh" --yes --plugin-dir="$PLUGIN_DIR"
 [ "$NEEDS_V0132_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.1-to-v0.13.2.sh" --yes --plugin-dir="$PLUGIN_DIR"
+[ "$NEEDS_V0140_PATCH" = yes ] && bash "$PLUGIN_DIR/scripts/migrate-v0.13.2-to-v0.14.0.sh" --yes --plugin-dir="$PLUGIN_DIR" $WITH_CODEX_FLAG
 ```
 
 Each script's verification block prints `X passed, Y failed`. Surface every


### PR DESCRIPTION
Two platform releases in one branch — espalier's wiring layer goes three-platform while `espalier/` stays the single source of truth.

**Codex (the v0.14.0 lane):**
- 12 skills as Codex repo skills via `.agents/skills/` symlinks (`$espalier`, `$espalier-fix`, …)
- Always-loaded rules via a generated `AGENTS.md` `## Espalier` section + platform-mapping table
- Coder/reviewer/security as `.codex/agents/harness-*.toml` subagents
- Both quality gates in `.codex/config.toml` — Codex shares Claude Code's hook JSON schema and exit-2 contract, so the same wrapper scripts serve both (hardened for `apply_patch` bodies and argv-array commands, which previously would have failed OPEN)
- Migration #21 (`migrate-v0.13.2-to-v0.14.0.sh`, `--with-codex` opt-in)

**Copilot (the v0.15.0 lane):**
- 12 skills as Agent Skills via `.github/skills/` symlinks — read by VS Code, Copilot CLI, AND the cloud coding agent (`/espalier…`)
- Rules via a `.github/copilot-instructions.md` `## Espalier` section
- `@harness-*` custom agents in `.github/agents/*.agent.md`
- Gates as Copilot hooks in `.github/hooks/espalier-gates.json`, bridged by the new `copilot-hook-adapter.sh` (camelCase `toolName`/`toolArgs` → `tool_name`/`tool_input`; non-zero `preToolUse` exits fail closed, preserving the exit-2 contract). Documented gap: VS Code chat runs no hooks — in-skill gates cover it.
- Migration #22 (`migrate-v0.14.0-to-v0.15.0.sh`, `--with-copilot` opt-in)

**Shared:** `--platforms` accepts any subset of `claude,codex,copilot` (`both`/`all` shorthands); `espalier/.platforms` records + unions; adding a platform later is one `--wire-only` run; legacy installs inferred as claude; claude-only output byte-stable at 46 checks (51 with codex, 56 with copilot).

Suites: bootstrap **117/117**, hooks **86/86**. Guides: `docs/codex-integration.md`, `docs/copilot-integration.md`; existing installs: `/espalier-migrate` (chain now TWENTY-TWO steps).
